### PR TITLE
Migrate from JwtUserInfoExtractor to DefaultJwtUserInfoExtractor

### DIFF
--- a/src/main/java/org/rutebanken/sobek/auth/OAuth2Config.java
+++ b/src/main/java/org/rutebanken/sobek/auth/OAuth2Config.java
@@ -4,7 +4,7 @@ import org.entur.oauth2.AuthorizedWebClientBuilder;
 import org.entur.oauth2.JwtRoleAssignmentExtractor;
 import org.entur.oauth2.multiissuer.MultiIssuerAuthenticationManagerResolver;
 import org.entur.oauth2.multiissuer.MultiIssuerAuthenticationManagerResolverBuilder;
-import org.entur.oauth2.user.JwtUserInfoExtractor;
+import org.entur.oauth2.user.DefaultJwtUserInfoExtractor;
 import org.entur.ror.permission.RemoteBabaRoleAssignmentExtractor;
 import org.entur.ror.permission.RemoteBabaUserInfoExtractor;
 import org.rutebanken.helper.organisation.RoleAssignmentExtractor;
@@ -30,7 +30,7 @@ public class OAuth2Config {
     )
     @Bean
     public UserInfoExtractor jwtUserInfoExtractor() {
-        return new JwtUserInfoExtractor();
+        return new DefaultJwtUserInfoExtractor();
     }
 
     /**


### PR DESCRIPTION
## Summary

- Replace deprecated `JwtUserInfoExtractor` with `DefaultJwtUserInfoExtractor`
- Update import statement to use the new class
- This migration follows the completion of the Auth0 tenant migration from legacy RoR tenant to Entur Partner tenant

## Context

The Auth0 tenant migration changed JWT token claims from custom namespaced claims (`https://ror.entur.io/preferred_username`) to standard OIDC claims (`preferred_username`). The `DefaultJwtUserInfoExtractor` class extracts user information from these standard OIDC claims.

The deprecated `JwtUserInfoExtractor` and `EnturJwtUserInfoExtractor` classes have been removed from rutebanken-helpers as of December 2, 2025.

## Changes

- Updated `OAuth2Config.java`:
  - Changed import from `org.entur.oauth2.user.JwtUserInfoExtractor`
  - To: `org.entur.oauth2.user.DefaultJwtUserInfoExtractor`
  - Updated bean instantiation to use new class

## Test plan

- [x] Code compiles successfully
- [x] All unit tests pass (`mvn clean verify`)
- [x] No behavioral changes expected - same interface, standard OIDC claims
- [ ] Verify authentication works in deployed environment
- [ ] Monitor authentication logs after deployment