### PR TITLE
Remove references to old ROR audiences

### DIFF
--- a/helm/sobek/env/values-kub-ent-dev.yaml
+++ b/helm/sobek/env/values-kub-ent-dev.yaml
@@ -12,10 +12,10 @@ auth0:
   entur:
     internal:
       url: https://internal.dev.entur.org/
-      audience: https://api.dev.entur.io,https://ror.api.dev.entur.io
+      audience: https://api.dev.entur.io
     partner:
       url: https://partner.dev.entur.org/
-      audience: https://ror.api.dev.entur.io,https://api.dev.entur.io
+      audience: https://api.dev.entur.io
   client:
       url: https://internal.dev.entur.org/oauth/token
       audience: https://api.dev.entur.io

--- a/helm/sobek/env/values-kub-ent-prd.yaml
+++ b/helm/sobek/env/values-kub-ent-prd.yaml
@@ -12,10 +12,10 @@ auth0:
   entur:
     internal:
       url: https://internal.entur.org/
-      audience: https://api.entur.io,https://ror.api.entur.io
+      audience: https://api.entur.io
     partner:
       url: https://partner.entur.org/
-      audience: https://api.entur.io,https://ror.api.entur.io
+      audience: https://api.entur.io
   client:
     url: https://internal.entur.org/oauth/token
     audience: https://api.entur.io

--- a/helm/sobek/env/values-kub-ent-tst.yaml
+++ b/helm/sobek/env/values-kub-ent-tst.yaml
@@ -12,10 +12,10 @@ auth0:
   entur:
     internal:
       url: https://internal.staging.entur.org/
-      audience: https://api.staging.entur.io,https://ror.api.staging.entur.io
+      audience: https://api.staging.entur.io
     partner:
       url: https://partner.staging.entur.org/
-      audience: https://ror.api.staging.entur.io,https://api.staging.entur.io
+      audience: https://api.staging.entur.io
   client:
     url: https://internal.staging.entur.org/oauth/token
     audience: https://api.staging.entur.io


### PR DESCRIPTION
### Summary

Remove references to old *ror* audiences. These are not in use anymore as the authentication is being moved to the Entur Partner auth solution.
Ref https://entur.slack.com/archives/C9RBE55L7/p1767868002042899

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to documentation only)
- [x] Other (please describe)
