### PR TITLE
Add criteria to fetch only current versions of the vehicles

### DIFF
--- a/sobek-repository/src/main/java/org/rutebanken/sobek/repository/VehicleTypeRepositoryImpl.java
+++ b/sobek-repository/src/main/java/org/rutebanken/sobek/repository/VehicleTypeRepositoryImpl.java
@@ -69,6 +69,7 @@ public class VehicleTypeRepositoryImpl implements VehicleTypeRepositoryCustom {
         return query.getResultList();
     }
 
+    @Override
     public void moveToDeckPlan(Long fromDeckPlanId, Long toDeckPlanId) {
         Query query = entityManager.createNativeQuery("UPDATE vehicle_type SET deck_plan_id = :toDeckPlanId WHERE deck_plan_id = :fromDeckPlanId " +
                 " and (from_date is null or from_date <= now()) and (to_date is null or to_date >= now())");


### PR DESCRIPTION
### Summary

Change fetch of VehicleTypes so that the vehicleType.vehicles will only include the current version of each vehicle

### Type of change
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to documentation only)
- [ ] Other (please describe)
