### PR TITLE
Fix MultilingualStringMapper concatenation bug

### DIFF
--- a/sobek-app/src/test/java/org/rutebanken/sobek/rest/graphql/GraphQLPagedQueriesTest.java
+++ b/sobek-app/src/test/java/org/rutebanken/sobek/rest/graphql/GraphQLPagedQueriesTest.java
@@ -81,7 +81,7 @@ class GraphQLPagedQueriesTest {
     void vehicleTypes_exposesNewFields() {
         given()
             .contentType(ContentType.JSON)
-            .body(gql("{ vehicleTypes(page: 0, size: 10) { content { id name { value lang } shortName { value } transportMode created changed changedBy versionComment version } totalElements } }"))
+            .body(gql("{ vehicleTypes(filter: { transportMode: bus }, page: 0, size: 10) { content { id name { value lang } shortName { value } transportMode created changed changedBy versionComment version } totalElements } }"))
         .when()
             .post("/services/vehicles/graphql")
         .then()

--- a/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/mapstruct/MultilingualStringMapper.java
+++ b/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/mapstruct/MultilingualStringMapper.java
@@ -55,11 +55,11 @@ public interface MultilingualStringMapper {
                            lang.set(textType.getLang());
                        }
                        if (textType.getValue() != null) {
-                           stringContent.set(stringContent + textType.getValue());
+                           stringContent.set(stringContent.get() + textType.getValue());
                        }
                    }
                } else {
-                   stringContent.set(stringContent + value.toString());
+                   stringContent.set(stringContent.get() + value.toString());
                }
            }
         });


### PR DESCRIPTION
## Summary
- Fix `AtomicReference.toString()` bug in `MultilingualStringMapper.mapToSobek()` — used `stringContent + value` instead of `stringContent.get() + value`, corrupting all imported multilingual strings (Name, ShortName, Description)
- Fix flaky `vehicleTypes_exposesNewFields` test that depended on `content[0]` ordering in shared DB — now filters by `transportMode: bus`

## Context
Introduced by the Spring Boot 4 rewrite in PR #76, surfaced when PR #86 added integration tests that assert on imported field values.

## Test plan
- [x] `mvn test` passes locally (31/31 in sobek-app, 0 failures)
- [ ] CI build passes on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)