### PR TITLE
Add single-Vehicle NeTEx export endpoint

### DIFF
--- a/sobek-app/src/main/java/org/rutebanken/sobek/rest/netex/publicationdelivery/VehicleExportResource.java
+++ b/sobek-app/src/main/java/org/rutebanken/sobek/rest/netex/publicationdelivery/VehicleExportResource.java
@@ -59,11 +59,15 @@ public class VehicleExportResource {
         return Response.ok(streamingOutput).build();
     }
 
+    // Path param is `{id}` (not `{netexId}`) for symmetry with
+    // @Path("deckplans/{id}") above — both endpoints look up by NeTEx id.
+    // Renaming one without the other would break the convention. If we
+    // want a rename, do it to both at once (tracked under the DRY-up in #101).
     @GET
     @Path("vehicles/{id}")
     @Produces(MediaType.APPLICATION_XML + "; charset=UTF-8")
     public Response getOneVehicle(@BeanParam ExportParametersDto exportParams, @PathParam("id") String id) {
-        log.info("Exporting publication delivery for Vehicle {}. {}", id, exportParams);
+        log.info("Exporting publication delivery for Vehicle NeTEx id {}. {}", id, exportParams);
 
         StreamingOutput streamingOutput = outputStream -> {
             try {

--- a/sobek-app/src/main/java/org/rutebanken/sobek/rest/netex/publicationdelivery/VehicleExportResource.java
+++ b/sobek-app/src/main/java/org/rutebanken/sobek/rest/netex/publicationdelivery/VehicleExportResource.java
@@ -58,4 +58,22 @@ public class VehicleExportResource {
 
         return Response.ok(streamingOutput).build();
     }
+
+    @GET
+    @Path("vehicles/{id}")
+    @Produces(MediaType.APPLICATION_XML + "; charset=UTF-8")
+    public Response getOneVehicle(@BeanParam ExportParametersDto exportParams, @PathParam("id") String id) {
+        log.info("Exporting publication delivery for Vehicle {}. {}", id, exportParams);
+
+        StreamingOutput streamingOutput = outputStream -> {
+            try {
+                streamingPublicationDelivery.streamOneVehicle(exportParams.toExportParams(), id, outputStream);
+            } catch (Exception e) {
+                log.warn("Could not stream vehicle. {}", e.getMessage(), e);
+                throw new RuntimeException(e);
+            }
+        };
+
+        return Response.ok(streamingOutput).build();
+    }
 }

--- a/sobek-app/src/test/java/org/rutebanken/sobek/rest/netex/publicationdelivery/VehicleExportIT.java
+++ b/sobek-app/src/test/java/org/rutebanken/sobek/rest/netex/publicationdelivery/VehicleExportIT.java
@@ -1,0 +1,140 @@
+package org.rutebanken.sobek.rest.netex.publicationdelivery;
+
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBElement;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Unmarshaller;
+import java.io.InputStream;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.rutebanken.netex.model.CompositeFrame;
+import org.rutebanken.netex.model.PublicationDeliveryStructure;
+import org.rutebanken.netex.model.ResourceFrame;
+import org.rutebanken.netex.model.Vehicle;
+import org.rutebanken.sobek.SobekTestApplication;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.server.LocalServerPort;
+
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT, classes = SobekTestApplication.class)
+class VehicleExportIT {
+
+    @LocalServerPort int port;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+    }
+
+    @Test
+    void exportVehicle_byId_returnsPublicationDeliveryWithOneMatchingVehicle() throws Exception {
+        String seedXml;
+        try (InputStream in = getClass().getResourceAsStream("/fixtures/vehicle-export-seed.xml")) {
+            seedXml = new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        }
+
+        String importResponseXml =
+                given()
+                        .contentType(ContentType.XML)
+                        .queryParam("importType", "ID_MATCH")
+                        .body(seedXml)
+                        .when()
+                        .post("/services/vehicles/netex")
+                        .then()
+                        .statusCode(200)
+                        .extract()
+                        .body()
+                        .asString();
+
+        Vehicle importedVehicle = extractSingleVehicle(unmarshal(importResponseXml));
+        assertThat(importedVehicle.getId()).isNotBlank();
+
+        String exportXml =
+                given()
+                        .accept(ContentType.XML)
+                        .when()
+                        .get("/services/vehicles/netex/vehicles/" + importedVehicle.getId())
+                        .then()
+                        .statusCode(200)
+                        .contentType(ContentType.XML.withCharset(StandardCharsets.UTF_8))
+                        .extract()
+                        .body()
+                        .asString();
+
+        Vehicle exportedVehicle = extractSingleVehicle(unmarshal(exportXml));
+        assertThat(exportedVehicle.getId()).isEqualTo(importedVehicle.getId());
+    }
+
+    @Test
+    void exportVehicle_unknownId_returnsEmptyResourceFrame() throws Exception {
+        String exportXml =
+                given()
+                        .accept(ContentType.XML)
+                        .when()
+                        .get("/services/vehicles/netex/vehicles/NMR:Vehicle:does-not-exist")
+                        .then()
+                        .statusCode(200)
+                        .contentType(ContentType.XML.withCharset(StandardCharsets.UTF_8))
+                        .extract()
+                        .body()
+                        .asString();
+
+        ResourceFrame frame = extractResourceFrame(unmarshal(exportXml));
+        assertThat(frame.getVehicles()).isNull();
+    }
+
+    private static Vehicle extractSingleVehicle(PublicationDeliveryStructure pd) {
+        ResourceFrame frame = extractResourceFrame(pd);
+        assertThat(frame.getVehicles()).isNotNull();
+        assertThat(frame.getVehicles().getVehicle()).hasSize(1);
+        return frame.getVehicles().getVehicle().get(0);
+    }
+
+    private static ResourceFrame extractResourceFrame(PublicationDeliveryStructure pd) {
+        return pd.getDataObjects().getCompositeFrameOrCommonFrame().stream()
+                .map(JAXBElement::getValue)
+                .flatMap(VehicleExportIT::flattenToResourceFrames)
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("No ResourceFrame in response"));
+    }
+
+    private static Stream<ResourceFrame> flattenToResourceFrames(Object frame) {
+        if (frame instanceof ResourceFrame rf) {
+            return Stream.of(rf);
+        }
+        if (frame instanceof CompositeFrame cf && cf.getFrames() != null) {
+            return cf.getFrames().getCommonFrame().stream()
+                    .map(JAXBElement::getValue)
+                    .filter(ResourceFrame.class::isInstance)
+                    .map(ResourceFrame.class::cast);
+        }
+        return Stream.empty();
+    }
+
+    private static final JAXBContext jaxbContext;
+
+    static {
+        try {
+            jaxbContext = JAXBContext.newInstance(PublicationDeliveryStructure.class);
+        } catch (JAXBException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private PublicationDeliveryStructure unmarshal(String xml) throws JAXBException {
+        Unmarshaller unmarshaller = jaxbContext.createUnmarshaller();
+        JAXBElement<PublicationDeliveryStructure> element =
+                (JAXBElement<PublicationDeliveryStructure>)
+                        unmarshaller.unmarshal(new StringReader(xml));
+        return element.getValue();
+    }
+}

--- a/sobek-app/src/test/resources/fixtures/vehicle-export-seed.xml
+++ b/sobek-app/src/test/resources/fixtures/vehicle-export-seed.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<PublicationDelivery xmlns="http://www.netex.org.uk/netex" version="1.0">
+    <PublicationTimestamp>2026-04-17T10:00:00.000Z</PublicationTimestamp>
+    <ParticipantRef>TST</ParticipantRef>
+    <dataObjects>
+        <ResourceFrame id="AKT:ResourceFrame:export-seed" version="1">
+            <FrameDefaults>
+                <DefaultLocale>
+                    <TimeZone>Europe/Oslo</TimeZone>
+                </DefaultLocale>
+            </FrameDefaults>
+            <vehicleTypes>
+                <VehicleType id="AKT:VehicleType:export-seed" version="1">
+                    <ValidBetween>
+                        <FromDate>2026-04-17T00:00:00</FromDate>
+                    </ValidBetween>
+                    <Name>ExportSeed Type</Name>
+                    <TransportMode>bus</TransportMode>
+                </VehicleType>
+            </vehicleTypes>
+            <vehicles>
+                <Vehicle id="AKT:Vehicle:export-seed" version="1">
+                    <ValidBetween>
+                        <FromDate>2026-04-17T00:00:00</FromDate>
+                    </ValidBetween>
+                    <Name lang="nb">ExportSeed Vehicle</Name>
+                    <RegistrationNumber>EXP-0001</RegistrationNumber>
+                    <TransportTypeRef ref="AKT:VehicleType:export-seed"/>
+                </Vehicle>
+            </vehicles>
+        </ResourceFrame>
+    </dataObjects>
+</PublicationDelivery>

--- a/sobek-service/src/main/java/org/rutebanken/sobek/exporter/StreamingPublicationDelivery.java
+++ b/sobek-service/src/main/java/org/rutebanken/sobek/exporter/StreamingPublicationDelivery.java
@@ -192,6 +192,7 @@ public class StreamingPublicationDelivery {
 
     }
 
+    // See also streamOneVehicle below — same skeleton; DRY-up tracked in #101.
     public void streamOneDeckPlan(ExportParams exportParams,String deckPlanId, OutputStream outputStream) throws JAXBException, XMLStreamException, IOException, InterruptedException, SAXException {
 
         logger.info("Streaming export of deckplan initiated. Export params: {}, deckPlan ID: {}", exportParams, deckPlanId);
@@ -217,9 +218,13 @@ public class StreamingPublicationDelivery {
         marshaller.marshal(netexObjectFactory.createPublicationDelivery(publicationDeliveryStructure), outputStream);
     }
 
-    public void streamOneVehicle(ExportParams exportParams, String vehicleId, OutputStream outputStream) throws JAXBException, XMLStreamException, IOException, InterruptedException, SAXException {
+    // NOTE: This is a near-duplicate of streamOneDeckPlan's CompositeFrame /
+    // ResourceFrame / marshal skeleton (only the prepareXxx call differs).
+    // DRY-up tracked in #101 — intentionally not refactored in the PR that
+    // introduced this method to keep the diff scoped to the new endpoint.
+    public void streamOneVehicle(ExportParams exportParams, String vehicleNetexId, OutputStream outputStream) throws JAXBException, XMLStreamException, IOException, InterruptedException, SAXException {
 
-        logger.info("Streaming export of vehicle initiated. Export params: {}, Vehicle ID: {}", exportParams, vehicleId);
+        logger.info("Streaming export of vehicle initiated. Export params: {}, Vehicle NeTEx id: {}", exportParams, vehicleNetexId);
 
         org.rutebanken.netex.model.CompositeFrame netexCompositeFrame = sobekComositeFrameExporter.createCompositeFrame("Composite frame " + exportParams);
 
@@ -230,7 +235,7 @@ public class StreamingPublicationDelivery {
         framesRelStructure.withCommonFrame(new ObjectFactory().createResourceFrame(netexResourceFrame));
         netexCompositeFrame.withFrames(framesRelStructure);
 
-        prepareOneVehicle(netexResourceFrame, vehicleId);
+        prepareOneVehicle(netexResourceFrame, vehicleNetexId);
 
         PublicationDeliveryStructure publicationDeliveryStructure = publicationDeliveryCreator.createPublicationDelivery(netexCompositeFrame);
 

--- a/sobek-service/src/main/java/org/rutebanken/sobek/exporter/StreamingPublicationDelivery.java
+++ b/sobek-service/src/main/java/org/rutebanken/sobek/exporter/StreamingPublicationDelivery.java
@@ -217,6 +217,44 @@ public class StreamingPublicationDelivery {
         marshaller.marshal(netexObjectFactory.createPublicationDelivery(publicationDeliveryStructure), outputStream);
     }
 
+    public void streamOneVehicle(ExportParams exportParams, String vehicleId, OutputStream outputStream) throws JAXBException, XMLStreamException, IOException, InterruptedException, SAXException {
+
+        logger.info("Streaming export of vehicle initiated. Export params: {}, Vehicle ID: {}", exportParams, vehicleId);
+
+        org.rutebanken.netex.model.CompositeFrame netexCompositeFrame = sobekComositeFrameExporter.createCompositeFrame("Composite frame " + exportParams);
+
+        logger.info("Mapping resource frame to netex model");
+        final org.rutebanken.netex.model.ResourceFrame netexResourceFrame = sobekResourceFrameExporter.createResourceFrame("Resource frame" + exportParams);
+
+        Frames_RelStructure framesRelStructure = new Frames_RelStructure();
+        framesRelStructure.withCommonFrame(new ObjectFactory().createResourceFrame(netexResourceFrame));
+        netexCompositeFrame.withFrames(framesRelStructure);
+
+        prepareOneVehicle(netexResourceFrame, vehicleId);
+
+        PublicationDeliveryStructure publicationDeliveryStructure = publicationDeliveryCreator.createPublicationDelivery(netexCompositeFrame);
+
+        Marshaller marshaller = createMarshaller();
+
+        logger.info("Start marshalling publication delivery");
+        marshaller.marshal(netexObjectFactory.createPublicationDelivery(publicationDeliveryStructure), outputStream);
+    }
+
+    private void prepareOneVehicle(org.rutebanken.netex.model.ResourceFrame resourceFrame, String vehicleNetexId) {
+        Vehicle vehicle = vehicleRepository.findFirstByNetexIdOrderByVersionDesc(vehicleNetexId);
+        if (vehicle == null) {
+            logger.info("No vehicle found for id {}", vehicleNetexId);
+            return;
+        }
+
+        VehiclesInFrame_RelStructure vehiclesInFrame_relStructure = new VehiclesInFrame_RelStructure();
+        List<org.rutebanken.netex.model.Vehicle> vehicles =
+                Collections.singletonList(vehicleMapper.mapToNetex(vehicle, mappingContext));
+
+        setField(VehiclesInFrame_RelStructure.class, "vehicle", vehiclesInFrame_relStructure, vehicles);
+        resourceFrame.setVehicles(vehiclesInFrame_relStructure);
+    }
+
 
 
     private void prepareVehicles(ExportParams exportParams, Set<Long> vehicleIds, AtomicInteger mappedVehicleCount, org.rutebanken.netex.model.ResourceFrame resourceFrame, EntitiesEvictor evicter) {


### PR DESCRIPTION
## Summary
- Add `GET /services/vehicles/netex/vehicles/{id}` to `VehicleExportResource`
- Add `streamOneVehicle` + private `prepareOneVehicle` to `StreamingPublicationDelivery`, mirroring `streamOneDeckPlan`
- Lookup by NeTEx id via inherited `findFirstByNetexIdOrderByVersionDesc` (latest version wins)

Closes #99. Ref: entur/hathor#26.

## Test plan
- [ ] `mvn clean install` succeeds
- [ ] `curl /services/vehicles/netex/vehicles/<id>` returns `<PublicationDelivery>` with one `<Vehicle>`
- [ ] Missing id returns 200 with empty `<ResourceFrame>` (known quirk, matches deckplans)

🤖 Generated with [Claude Code](https://claude.com/claude-code)