### PR TITLE
Feature/add organization access control

### DIFF
--- a/sobek-app/src/main/java/org/rutebanken/sobek/auth/check/SobekOriganisationChecker.java
+++ b/sobek-app/src/main/java/org/rutebanken/sobek/auth/check/SobekOriganisationChecker.java
@@ -19,6 +19,7 @@ package org.rutebanken.sobek.auth.check;
 import org.rutebanken.helper.organisation.OrganisationChecker;
 import org.rutebanken.helper.organisation.RoleAssignment;
 import org.rutebanken.netex.model.Vehicle;
+import org.rutebanken.sobek.model.authorization.OwnedEntity;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -31,13 +32,11 @@ public class SobekOriganisationChecker implements OrganisationChecker {
     @Override
     public boolean entityMatchesOrganisationRef(RoleAssignment roleAssignment, Object entity) {
 
-        if (entity instanceof Vehicle vehicle) {
-            if (vehicle.getTransportOrganisationRef() != null) {
-                String orgRef = vehicle.getTransportOrganisationRef().getValue().getRef();
-                if (orgRef != null) {
-                    logger.debug("Found org ref {} for entity. Returning true if it matches role assignment organisation :{}", orgRef, roleAssignment.getOrganisation());
-                    return orgRef.endsWith(":" + roleAssignment.getOrganisation());
-                }
+        if (entity instanceof OwnedEntity ownedEntity) {
+            if (ownedEntity.getDataOwnerRef() != null) {
+                String orgRef = ":" + ownedEntity.getDataOwnerRef().replace(":", "/");
+                logger.debug("Found org ref {} for entity. Returning true if the role assignment contains reference to the organisation", orgRef);
+                return roleAssignment.getEntityClassifications().get("Vehicle").stream().anyMatch(c -> c.endsWith(orgRef));
             }
             logger.debug("Org ref is null for entity: {}", entity);
             return true;

--- a/sobek-app/src/main/java/org/rutebanken/sobek/auth/check/SobekOriganisationChecker.java
+++ b/sobek-app/src/main/java/org/rutebanken/sobek/auth/check/SobekOriganisationChecker.java
@@ -34,9 +34,9 @@ public class SobekOriganisationChecker implements OrganisationChecker {
 
         if (entity instanceof OwnedEntity ownedEntity) {
             if (ownedEntity.getDataOwnerRef() != null) {
-                String orgRef = ":" + ownedEntity.getDataOwnerRef().replace(":", "/");
+                String orgRef = ownedEntity.getDataOwnerRef().replace(":", "/");
                 logger.debug("Found org ref {} for entity. Returning true if the role assignment contains reference to the organisation", orgRef);
-                return roleAssignment.getEntityClassifications().get("Vehicle").stream().anyMatch(c -> c.endsWith(orgRef));
+                return roleAssignment.getEntityClassifications().get("DataOwner").stream().anyMatch(c -> c.equals(orgRef));
             }
             logger.debug("Org ref is null for entity: {}", entity);
             return true;

--- a/sobek-app/src/main/java/org/rutebanken/sobek/auth/check/SobekOriganisationChecker.java
+++ b/sobek-app/src/main/java/org/rutebanken/sobek/auth/check/SobekOriganisationChecker.java
@@ -37,7 +37,17 @@ public class SobekOriganisationChecker implements OrganisationChecker {
             if (ownedEntity.getDataOwnerRef() != null) {
                 String orgRef = ownedEntity.getDataOwnerRef().replace(":", "/");
                 logger.debug("Found org ref {} for entity. Returning true if the role assignment contains reference to the organisation", orgRef);
-                return roleAssignment.getEntityClassifications().get(CLASSIFICATION_DATA_OWNER).stream().anyMatch(c -> c.equals(orgRef));
+                var entityClassifications = roleAssignment.getEntityClassifications();
+                if (entityClassifications == null) {
+                    logger.warn("Role assignment has no entity classifications. Denying organisation match for org ref {}", orgRef);
+                    return false;
+                }
+                var dataOwnerClassifications = entityClassifications.get(CLASSIFICATION_DATA_OWNER);
+                if (dataOwnerClassifications == null) {
+                    logger.warn("Role assignment is missing {} classification. Denying organisation match for org ref {}", CLASSIFICATION_DATA_OWNER, orgRef);
+                    return false;
+                }
+                return dataOwnerClassifications.stream().anyMatch(c -> c.equals(orgRef));
             }
             logger.debug("Org ref is null for entity: {}", entity);
             return true;

--- a/sobek-app/src/main/java/org/rutebanken/sobek/auth/check/SobekOriganisationChecker.java
+++ b/sobek-app/src/main/java/org/rutebanken/sobek/auth/check/SobekOriganisationChecker.java
@@ -18,11 +18,12 @@ package org.rutebanken.sobek.auth.check;
 
 import org.rutebanken.helper.organisation.OrganisationChecker;
 import org.rutebanken.helper.organisation.RoleAssignment;
-import org.rutebanken.netex.model.Vehicle;
 import org.rutebanken.sobek.model.authorization.OwnedEntity;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
+
+import static org.rutebanken.sobek.auth.AuthorizationConstants.CLASSIFICATION_DATA_OWNER;
 
 @Service
 public class SobekOriganisationChecker implements OrganisationChecker {
@@ -36,7 +37,7 @@ public class SobekOriganisationChecker implements OrganisationChecker {
             if (ownedEntity.getDataOwnerRef() != null) {
                 String orgRef = ownedEntity.getDataOwnerRef().replace(":", "/");
                 logger.debug("Found org ref {} for entity. Returning true if the role assignment contains reference to the organisation", orgRef);
-                return roleAssignment.getEntityClassifications().get("DataOwner").stream().anyMatch(c -> c.equals(orgRef));
+                return roleAssignment.getEntityClassifications().get(CLASSIFICATION_DATA_OWNER).stream().anyMatch(c -> c.equals(orgRef));
             }
             logger.debug("Org ref is null for entity: {}", entity);
             return true;

--- a/sobek-app/src/main/java/org/rutebanken/sobek/config/AuthorizationServiceConfig.java
+++ b/sobek-app/src/main/java/org/rutebanken/sobek/config/AuthorizationServiceConfig.java
@@ -27,6 +27,10 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 @Configuration
 public class AuthorizationServiceConfig {
 
@@ -47,11 +51,8 @@ public class AuthorizationServiceConfig {
                                                                          SobekOriganisationChecker sobekOriganisationChecker,
                                                                          SobekEntityResolver sobekEntityResolver) {
 
-        // // Should be made configurable
-        // Map<String, List<String>> fieldMappings = new HashMap<>();
-        // fieldMappings.put(SUBMODE.toLowerCase(), Arrays.asList("airSubmode", "busSubmode", "coachSubmode", "funicularSubmode", "metroSubmode", "tramSubmode", "telecabinSubmode", "railSubmode", "waterSubmode"));
+        Map<String, List<String>> fieldMappings = new HashMap<>();
 
-
-        return new ReflectionAuthorizationService(roleAssignmentExtractor, authorizationEnabled, sobekOriganisationChecker, null, sobekEntityResolver, null);
+        return new ReflectionAuthorizationService(roleAssignmentExtractor, authorizationEnabled, sobekOriganisationChecker, null, sobekEntityResolver, fieldMappings);
     }
 }

--- a/sobek-app/src/main/java/org/rutebanken/sobek/rest/graphql/GraphQLNames.java
+++ b/sobek-app/src/main/java/org/rutebanken/sobek/rest/graphql/GraphQLNames.java
@@ -108,6 +108,9 @@ public class GraphQLNames {
     public static final String SIZE = "size";
     public static final String SIZE_ARG_DESCRIPTION = "Number of hits per page when using pagination - default is " + DEFAULT_SIZE_VALUE;
 
+    public static final String USER_AUTHORIZED = "onlyUserAuthorized";
+    public static final String USER_AUTHORIZED_ARG_DESCRIPTION = "Only return entities that the user is authorized to use";
+
     public static final String ALL_VERSIONS = "allVersions";
     public static final String ALL_VERSIONS_ARG_DESCRIPTION = "Fetch all versions for entities in result";
 

--- a/sobek-app/src/main/java/org/rutebanken/sobek/rest/graphql/RegisterGraphQLSchema.java
+++ b/sobek-app/src/main/java/org/rutebanken/sobek/rest/graphql/RegisterGraphQLSchema.java
@@ -15,6 +15,7 @@
 
 package org.rutebanken.sobek.rest.graphql;
 
+import graphql.language.BooleanValue;
 import graphql.language.IntValue;
 import graphql.schema.DataFetcher;
 import graphql.schema.FieldCoordinates;
@@ -30,7 +31,6 @@ import org.rutebanken.sobek.auth.AuthorizationService;
 import org.rutebanken.sobek.model.DataManagedObjectStructure;
 import org.rutebanken.sobek.model.identification.IdentifiedEntity;
 import org.rutebanken.sobek.rest.graphql.fetchers.*;
-import org.rutebanken.sobek.rest.graphql.resolvers.MutableTypeResolver;
 import org.rutebanken.sobek.rest.graphql.scalars.DateScalar;
 import org.rutebanken.sobek.rest.graphql.types.*;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -55,6 +55,7 @@ public class RegisterGraphQLSchema {
 
     public final static int DEFAULT_PAGE_VALUE = 0;
     public final static int DEFAULT_SIZE_VALUE = 20;
+    public final static boolean DEFAULT_USER_AUTHORIZED_VALUE = false;
 
     public GraphQLSchema vehicleRegisterSchema;
 
@@ -125,8 +126,8 @@ public class RegisterGraphQLSchema {
                 .name(INPUT_TYPE_ORGANISATIONS_FILTER)
                 .field(newInputObjectField().name(IDS).type(new GraphQLList(new GraphQLNonNull(GraphQLString))).description("Batch lookup by NeTEx IDs"))
                 .field(newInputObjectField().name(ORGANISATION_TYPE).type(organisationTypeEnumType).description("Filter by organisation type"))
+                .field(newInputObjectField().name(USER_AUTHORIZED).type(GraphQLBoolean).description(USER_AUTHORIZED_ARG_DESCRIPTION).defaultValueLiteral(BooleanValue.of(DEFAULT_USER_AUTHORIZED_VALUE)))
                 .build();
-
 
         GraphQLObjectType deckPlanPageType = createPageType(OUTPUT_TYPE_DECK_PLAN_PAGE, deckPlanObjectType);
         GraphQLObjectType organisationPageType = createPageType(OUTPUT_TYPE_ORGANISATION_PAGE, organisationType);

--- a/sobek-app/src/main/java/org/rutebanken/sobek/rest/graphql/fetchers/OrganisationFetcher.java
+++ b/sobek-app/src/main/java/org/rutebanken/sobek/rest/graphql/fetchers/OrganisationFetcher.java
@@ -18,6 +18,7 @@ package org.rutebanken.sobek.rest.graphql.fetchers;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 import org.rutebanken.netex.model.OrganisationTypeEnumeration;
+import org.rutebanken.sobek.auth.AuthorizationService;
 import org.rutebanken.sobek.repository.OrganisationRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
@@ -28,8 +29,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.rutebanken.sobek.rest.graphql.GraphQLNames.*;
-import static org.rutebanken.sobek.rest.graphql.RegisterGraphQLSchema.DEFAULT_PAGE_VALUE;
-import static org.rutebanken.sobek.rest.graphql.RegisterGraphQLSchema.DEFAULT_SIZE_VALUE;
+import static org.rutebanken.sobek.rest.graphql.RegisterGraphQLSchema.*;
 
 @Service("organisationFetcher")
 @Transactional
@@ -38,6 +38,9 @@ class OrganisationFetcher implements DataFetcher<Map<String, Object>> {
     @Autowired
     private OrganisationRepository organisationRepository;
 
+    @Autowired
+    private AuthorizationService authorizationService;
+
     @Override
     @SuppressWarnings("unchecked")
     public Map<String, Object> get(DataFetchingEnvironment env) {
@@ -45,19 +48,30 @@ class OrganisationFetcher implements DataFetcher<Map<String, Object>> {
         int size = env.getArgumentOrDefault(SIZE, DEFAULT_SIZE_VALUE);
 
         Map<String, Object> filter = env.getArgument(FILTER);
+
         List<String> ids = null;
         OrganisationTypeEnumeration type = null;
+        Boolean onlyAuthorized = false;
+
         if (filter != null) {
             ids = (List<String>) filter.get(IDS);
             Object orgArg = filter.get(ORGANISATION_TYPE);
+
             if (orgArg instanceof org.rutebanken.netex.model.OrganisationTypeEnumeration t) {
                 type = t;
             } else if (orgArg instanceof String s) {
                 type = OrganisationTypeEnumeration.fromValue(s);
             }
+
+            onlyAuthorized = (Boolean)filter.get(USER_AUTHORIZED);
         }
 
-        var result = organisationRepository.findCurrentFiltered(ids, type, PageRequest.of(page, size));
+        List<String> authorizedIds = null;
+        if(onlyAuthorized != null && onlyAuthorized) {
+            authorizedIds = authorizationService.getOrganisationRefsUserIsAuthorizedFor();
+        }
+
+        var result = organisationRepository.findCurrentFiltered(ids, type, authorizedIds, PageRequest.of(page, size));
         return PageResult.from(result, page, size);
     }
 }

--- a/sobek-app/src/main/resources/application-local.properties
+++ b/sobek-app/src/main/resources/application-local.properties
@@ -59,13 +59,14 @@ sobek.oauth2.resourceserver.auth0.entur.partner.jwt.audience=https://api.dev.ent
 sobek.oauth2.resourceserver.auth0.entur.partner.jwt.issuer-uri=https://partner.dev.entur.org/
 
 # For testing startup with baba as role assignment extractor
-#sobek.security.role.assignment.extractor=baba
-#sobek.user.permission.rest.service.url=http://baba.dev.entur.internal/services/organisations/users
-#spring.security.oauth2.client.registration.internal.authorization-grant-type=client_credentials
-#spring.security.oauth2.client.provider.internal.token-uri=https://internal.dev.entur.org/
-#sobek.oauth2.client.audience=https://api.dev.entur.io
-#spring.security.oauth2.client.registration.internal.client-id=id
-#spring.security.oauth2.client.registration.internal.client-secret=secret
+sobek.security.role.assignment.extractor=baba
+sobek.user.permission.rest.service.url=https://api.dev.entur.io/timetable-admin/v1/organisations/users
+spring.security.oauth2.client.registration.internal.authorization-grant-type=client_credentials
+sobek.oauth2.client.audience=https://api.dev.entur.io
+spring.security.oauth2.client.registration.internal.client-id=${SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_INTERNAL_CLIENT_ID}
+spring.security.oauth2.client.registration.internal.client-secret=${SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_INTERNAL_CLIENT_SECRET}
+spring.security.oauth2.client.provider.internal.token-uri=https://internal.dev.entur.org/oauth/token
+
 
 spring.cloud.gcp.pubsub.enabled=false
 
@@ -92,8 +93,8 @@ blobstore.s3.endpoint-override=http://localhost:37566
 spring.cloud.aws.region.static=eu-north-1
 
 security.basic.enabled=false
-management.security.enabled=false
-authorization.enabled=false
+management.security.enabled=true
+authorization.enabled=true
 rutebanken.kubernetes.enabled=false
 
 async.export.path=/tmp

--- a/sobek-app/src/main/resources/db/migration/V8__Add_DataOwnerRef.sql
+++ b/sobek-app/src/main/resources/db/migration/V8__Add_DataOwnerRef.sql
@@ -1,0 +1,11 @@
+ALTER TABLE deck_plan
+    ADD data_owner_ref VARCHAR(255);
+
+ALTER TABLE train
+    ADD data_owner_ref VARCHAR(255);
+
+ALTER TABLE vehicle
+    ADD data_owner_ref VARCHAR(255);
+
+ALTER TABLE vehicle_type
+    ADD data_owner_ref VARCHAR(255);

--- a/sobek-app/src/test/java/org/rutebanken/sobek/rest/graphql/GraphQLPagedQueriesTest.java
+++ b/sobek-app/src/test/java/org/rutebanken/sobek/rest/graphql/GraphQLPagedQueriesTest.java
@@ -107,6 +107,20 @@ class GraphQLPagedQueriesTest {
     }
 
     @Test
+    void organisations_filterByUserAuthorizedOrganisations() {
+        given()
+                .contentType(ContentType.JSON)
+                .body(gql("{ organisations(page: 0, size: 1000, filter: { onlyUserAuthorized: true }  ) { content { id } totalElements page size } }"))
+                .when()
+                .post("/services/vehicles/graphql")
+                .then()
+                .statusCode(200)
+                .body("data.organisations.content", is(not(empty())))
+                .body("data.organisations.totalElements", greaterThanOrEqualTo(1))
+                .body("data.organisations.page", equalTo(0));
+    }
+
+    @Test
     void vehicleTypes_exposesNewFields() {
         given()
             .contentType(ContentType.JSON)

--- a/sobek-app/src/test/resources/fixtures/vehicle-export-seed.xml
+++ b/sobek-app/src/test/resources/fixtures/vehicle-export-seed.xml
@@ -5,12 +5,23 @@
     <dataObjects>
         <ResourceFrame id="AKT:ResourceFrame:export-seed" version="1">
             <FrameDefaults>
+                <DefaultResponsibilitySetRef ref="TST:ResponsibilitySet:1" />
                 <DefaultLocale>
                     <TimeZone>Europe/Oslo</TimeZone>
                 </DefaultLocale>
             </FrameDefaults>
+            <responsibilitySets>
+                <ResponsibilitySet id="TST:ResponsibilitySet:1" version="1">
+                    <roles>
+                        <ResponsibilityRoleAssignment id="TST:ResponsibilityRoleAssignment:1" version="1">
+                            <DataRoleType>owns</DataRoleType>
+                            <ResponsibleOrganisationRef ref="NOG:Authority:cP4aPiJ7c39"/>
+                        </ResponsibilityRoleAssignment>
+                    </roles>
+                </ResponsibilitySet>
+            </responsibilitySets>
             <vehicleTypes>
-                <VehicleType id="AKT:VehicleType:export-seed" version="1">
+                <VehicleType id="AKT:VehicleType:export-seed" version="1" >
                     <ValidBetween>
                         <FromDate>2026-04-17T00:00:00</FromDate>
                     </ValidBetween>
@@ -19,7 +30,7 @@
                 </VehicleType>
             </vehicleTypes>
             <vehicles>
-                <Vehicle id="AKT:Vehicle:export-seed" version="1">
+                <Vehicle id="AKT:Vehicle:export-seed" version="1" >
                     <ValidBetween>
                         <FromDate>2026-04-17T00:00:00</FromDate>
                     </ValidBetween>

--- a/sobek-app/src/test/resources/fixtures/vehicle-type-import-1.xml
+++ b/sobek-app/src/test/resources/fixtures/vehicle-type-import-1.xml
@@ -5,12 +5,23 @@
     <dataObjects>
         <ResourceFrame version="1" id="TST:ResourceFrame:1">
             <FrameDefaults>
+                <DefaultResponsibilitySetRef ref="TST:ResponsibilitySet:1" />
                 <DefaultLocale>
                     <TimeZone>Europe/Oslo</TimeZone>
                 </DefaultLocale>
             </FrameDefaults>
+            <responsibilitySets>
+                <ResponsibilitySet id="TST:ResponsibilitySet:1" version="1">
+                    <roles>
+                        <ResponsibilityRoleAssignment id="TST:ResponsibilityRoleAssignment:1" version="1">
+                            <DataRoleType>owns</DataRoleType>
+                            <ResponsibleOrganisationRef ref="NOG:Authority:cP4aPiJ7c39"/>
+                        </ResponsibilityRoleAssignment>
+                    </roles>
+                </ResponsibilitySet>
+            </responsibilitySets>
             <vehicleTypes>
-                <VehicleType version="1" id="TST:VehicleType:1">
+                <VehicleType version="1" id="TST:VehicleType:1" >
                     <Name><Text>Exqui City 24</Text></Name>
                     <Description><Text>Van Hool articulated electric bus</Text></Description>
                     <EuroClass>Euro6</EuroClass>
@@ -32,7 +43,7 @@
                     <Height>3.40</Height>
                     <Weight>19500</Weight>
                 </VehicleType>
-                <VehicleType version="1" id="TST:VehicleType:2">
+                <VehicleType version="1" id="TST:VehicleType:2" >
                     <Name><Text>Exqui City 24</Text></Name>
                     <Description><Text>Van Hool articulated electric bus</Text></Description>
                     <EuroClass>Euro6</EuroClass>

--- a/sobek-app/src/test/resources/fixtures/vehicle-type-import-basic.xml
+++ b/sobek-app/src/test/resources/fixtures/vehicle-type-import-basic.xml
@@ -5,10 +5,21 @@
     <dataObjects>
         <ResourceFrame id="RF:1" version="1">
             <FrameDefaults>
+                <DefaultResponsibilitySetRef ref="TST:ResponsibilitySet:1" />
                 <DefaultLocale>
                     <TimeZone>Europe/Oslo</TimeZone>
                 </DefaultLocale>
             </FrameDefaults>
+            <responsibilitySets>
+                <ResponsibilitySet id="TST:ResponsibilitySet:1" version="1">
+                    <roles>
+                        <ResponsibilityRoleAssignment id="TST:ResponsibilityRoleAssignment:1" version="1">
+                            <DataRoleType>owns</DataRoleType>
+                            <ResponsibleOrganisationRef ref="NOG:Authority:cP4aPiJ7c39"/>
+                        </ResponsibilityRoleAssignment>
+                    </roles>
+                </ResponsibilitySet>
+            </responsibilitySets>
             <vehicleTypes>
                 <VehicleType id="AKT:VehicleType:123" version="1">
                     <Name lang="nb"><Text>Exqui City 24</Text></Name>

--- a/sobek-app/src/test/resources/fixtures/vehicle-type-import.xml
+++ b/sobek-app/src/test/resources/fixtures/vehicle-type-import.xml
@@ -5,12 +5,23 @@
     <dataObjects>
         <ResourceFrame version="1" id="TST:ResourceFrame:1">
             <FrameDefaults>
+                <DefaultResponsibilitySetRef ref="TST:ResponsibilitySet:1" />
                 <DefaultLocale>
                     <TimeZone>Europe/Oslo</TimeZone>
                 </DefaultLocale>
             </FrameDefaults>
+            <responsibilitySets>
+                <ResponsibilitySet id="TST:ResponsibilitySet:1" version="1">
+                    <roles>
+                        <ResponsibilityRoleAssignment id="TST:ResponsibilityRoleAssignment:1" version="1">
+                            <DataRoleType>owns</DataRoleType>
+                            <ResponsibleOrganisationRef ref="NOG:Authority:cP4aPiJ7c39"/>
+                        </ResponsibilityRoleAssignment>
+                    </roles>
+                </ResponsibilitySet>
+            </responsibilitySets>
             <vehicleTypes>
-                <VehicleType version="1" id="TST:VehicleType:1">
+                <VehicleType version="1" id="TST:VehicleType:1" >
                     <Name><Text>Exqui City 24</Text></Name>
                     <Description><Text>Van Hool articulated electric bus</Text></Description>
                     <EuroClass>Euro6</EuroClass>

--- a/sobek-model/src/main/java/org/rutebanken/sobek/model/authorization/OwnedEntity.java
+++ b/sobek-model/src/main/java/org/rutebanken/sobek/model/authorization/OwnedEntity.java
@@ -1,0 +1,7 @@
+package org.rutebanken.sobek.model.authorization;
+
+
+public interface OwnedEntity {
+    String getDataOwnerRef();
+    void setDataOwnerRef(String dataOwnerRef);
+}

--- a/sobek-model/src/main/java/org/rutebanken/sobek/model/vehicle/DeckPlan.java
+++ b/sobek-model/src/main/java/org/rutebanken/sobek/model/vehicle/DeckPlan.java
@@ -16,6 +16,7 @@ import org.rutebanken.sobek.model.DataManagedObjectStructure;
 import org.rutebanken.sobek.model.EmbeddableMultilingualString;
 import org.rutebanken.sobek.model.EntityInVersionStructure;
 import org.rutebanken.sobek.model.Value;
+import org.rutebanken.sobek.model.authorization.OwnedEntity;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -23,7 +24,7 @@ import java.util.List;
 @Entity
 @Getter
 @Setter
-public class DeckPlan extends DataManagedObjectStructure {
+public class DeckPlan extends DataManagedObjectStructure implements OwnedEntity {
     @AttributeOverrides({
             @AttributeOverride(name = "value", column = @Column(name = "name_value")),
             @AttributeOverride(name = "lang", column = @Column(name = "name_lang", length = 5))
@@ -44,6 +45,17 @@ public class DeckPlan extends DataManagedObjectStructure {
     @Transient
     private ValidityConditions_RelStructure configurationConditions;
 
+    private String dataOwnerRef;
+
+    @Override
+    public String getDataOwnerRef() {
+        return dataOwnerRef;
+    }
+
+    @Override
+    public void setDataOwnerRef(String dataOwnerRef) {
+        this.dataOwnerRef = dataOwnerRef;
+    }
     // TODO - TBD
 //    private DeckLevels_RelStructure deckLevels;
 

--- a/sobek-model/src/main/java/org/rutebanken/sobek/model/vehicle/TransportType_VersionStructure.java
+++ b/sobek-model/src/main/java/org/rutebanken/sobek/model/vehicle/TransportType_VersionStructure.java
@@ -4,15 +4,15 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
 import org.rutebanken.sobek.model.*;
+import org.rutebanken.sobek.model.authorization.OwnedEntity;
 
 import java.math.BigDecimal;
-import java.util.ArrayList;
 import java.util.List;
 
 @MappedSuperclass
 @Getter
 @Setter
-public class TransportType_VersionStructure extends DataManagedObjectStructure {
+public class TransportType_VersionStructure extends DataManagedObjectStructure implements OwnedEntity {
     @AttributeOverrides({
             @AttributeOverride(name = "value", column = @Column(name = "name_value")),
             @AttributeOverride(name = "lang", column = @Column(name = "name_lang", length = 5))
@@ -51,5 +51,15 @@ public class TransportType_VersionStructure extends DataManagedObjectStructure {
     @ManyToOne
     private org.rutebanken.sobek.model.vehicle.DeckPlan deckPlan;
 
+    private String dataOwnerRef;
 
+    @Override
+    public String getDataOwnerRef() {
+        return dataOwnerRef;
+    }
+
+    @Override
+    public void setDataOwnerRef(String dataOwnerRef) {
+        this.dataOwnerRef = dataOwnerRef;
+    }
 }

--- a/sobek-model/src/main/java/org/rutebanken/sobek/model/vehicle/Vehicle_VersionStructure.java
+++ b/sobek-model/src/main/java/org/rutebanken/sobek/model/vehicle/Vehicle_VersionStructure.java
@@ -6,13 +6,14 @@ import lombok.Getter;
 import lombok.Setter;
 
 import org.rutebanken.sobek.model.*;
+import org.rutebanken.sobek.model.authorization.OwnedEntity;
 
 import java.time.Instant;
 
 @MappedSuperclass
 @Getter
 @Setter
-public class Vehicle_VersionStructure extends DataManagedObjectStructure {
+public class Vehicle_VersionStructure extends DataManagedObjectStructure implements OwnedEntity {
     @AttributeOverrides({
             @AttributeOverride(name = "value", column = @Column(name = "name_value")),
             @AttributeOverride(name = "lang", column = @Column(name = "name_lang", length = 5))
@@ -60,5 +61,17 @@ public class Vehicle_VersionStructure extends DataManagedObjectStructure {
     @Transient
     private Equipments_RelStructure actualVehicleEquipments;
     private Boolean monitored;
+
+    private String dataOwnerRef;
+
+    @Override
+    public String getDataOwnerRef() {
+        return dataOwnerRef;
+    }
+
+    @Override
+    public void setDataOwnerRef(String dataOwnerRef) {
+        this.dataOwnerRef = dataOwnerRef;
+    }
 
 }

--- a/sobek-repository/src/main/java/org/rutebanken/sobek/repository/OrganisationRepository.java
+++ b/sobek-repository/src/main/java/org/rutebanken/sobek/repository/OrganisationRepository.java
@@ -8,6 +8,6 @@ import org.springframework.data.domain.Pageable;
 import java.util.List;
 
 public interface OrganisationRepository {
-    Page<Organisation> findCurrentFiltered(List<String> ids, OrganisationTypeEnumeration organisationType, Pageable pageable);
+    Page<Organisation> findCurrentFiltered(List<String> ids, OrganisationTypeEnumeration organisationType, List<String> authorizedIds, Pageable pageable);
 }
 

--- a/sobek-repository/src/main/java/org/rutebanken/sobek/repository/OrganisationRepositoryImpl.java
+++ b/sobek-repository/src/main/java/org/rutebanken/sobek/repository/OrganisationRepositoryImpl.java
@@ -28,7 +28,7 @@ public class OrganisationRepositoryImpl implements OrganisationRepository {
     }
 
     @Override
-    public Page<Organisation> findCurrentFiltered(List<String> ids, OrganisationTypeEnumeration organisationType, Pageable pageable) {
+    public Page<Organisation> findCurrentFiltered(List<String> ids, OrganisationTypeEnumeration organisationType, List<String> authorizedIds, Pageable pageable) {
         List<? extends Organisation_VersionStructure> organisations;
 
         if(organisationType == null) {
@@ -43,6 +43,14 @@ public class OrganisationRepositoryImpl implements OrganisationRepository {
 
         if(ids != null && !ids.isEmpty()) {
             Set<String> idSet = new HashSet<>(ids);
+            organisations = organisations
+                    .stream()
+                    .filter(org -> idSet.contains(org.getId()))
+                    .toList();
+        }
+
+        if(authorizedIds != null) {
+            Set<String> idSet = new HashSet<>(authorizedIds);
             organisations = organisations
                     .stream()
                     .filter(org -> idSet.contains(org.getId()))
@@ -67,14 +75,13 @@ public class OrganisationRepositoryImpl implements OrganisationRepository {
 
     private List<Organisation> mapOrganisations(List<? extends Organisation_VersionStructure> organisations) {
         // Convert to Organisation records
-        List<Organisation> organisationList = organisations.stream()
+        return organisations.stream()
                 .map(org -> new Organisation(
                         org.getId(),
                         multilingualStringMapper.mapToSobek(org.getName()),
                         getOrganisationType(org)
                 ))
                 .toList();
-        return organisationList;
     }
 
     private OrganisationTypeEnumeration getOrganisationType(Organisation_VersionStructure org) {

--- a/sobek-service/src/main/java/org/rutebanken/sobek/auth/AuthorizationConstants.java
+++ b/sobek-service/src/main/java/org/rutebanken/sobek/auth/AuthorizationConstants.java
@@ -1,0 +1,9 @@
+package org.rutebanken.sobek.auth;
+
+public final class AuthorizationConstants {
+    public static final String ROLE_DELETE_VEHICLE_DATA = "deleteVehicleType";
+    public static final String ROLE_EDIT_VEHICLE_DATA = "editVehicleType";
+
+    private AuthorizationConstants() {
+    }
+}

--- a/sobek-service/src/main/java/org/rutebanken/sobek/auth/AuthorizationConstants.java
+++ b/sobek-service/src/main/java/org/rutebanken/sobek/auth/AuthorizationConstants.java
@@ -3,6 +3,7 @@ package org.rutebanken.sobek.auth;
 public final class AuthorizationConstants {
     public static final String ROLE_DELETE_VEHICLE_DATA = "deleteVehicleType";
     public static final String ROLE_EDIT_VEHICLE_DATA = "editVehicleType";
+    public static final String CLASSIFICATION_DATA_OWNER = "DataOwner";
 
     private AuthorizationConstants() {
     }

--- a/sobek-service/src/main/java/org/rutebanken/sobek/auth/AuthorizationService.java
+++ b/sobek-service/src/main/java/org/rutebanken/sobek/auth/AuthorizationService.java
@@ -4,6 +4,7 @@ import org.rutebanken.sobek.model.EntityStructure;
 import org.springframework.security.access.AccessDeniedException;
 
 import java.util.Collection;
+import java.util.List;
 
 /**
  * Authorization service interface for managing authorization of users to perform operations
@@ -64,4 +65,10 @@ public interface AuthorizationService {
       * @return {@code true} if the user is a guest, otherwise {@code false}.
       */
     boolean isGuest();
+
+    /**
+     * Get the organisation refs the user is authorized for. If authorization is disabled, return null, which means "all organisations".
+     * @return A list of organisation refs, e.g. "NOG:Authority:23A2N7V6Blr"
+     */
+    List<String> getOrganisationRefsUserIsAuthorizedFor();
 }

--- a/sobek-service/src/main/java/org/rutebanken/sobek/auth/DefaultAuthorizationService.java
+++ b/sobek-service/src/main/java/org/rutebanken/sobek/auth/DefaultAuthorizationService.java
@@ -108,7 +108,8 @@ public class DefaultAuthorizationService implements AuthorizationService {
 
         Set<String> organisationRefs = new HashSet<>();
         roleAssignments.forEach(roleAssignment -> {
-            if(roleAssignment.getRole().equals(ROLE_EDIT_VEHICLE_DATA)) {  // Maybe return also "read" or "delete"? Review this later on, for now only "edit" is needed.
+            if(roleAssignment.getRole().equals(ROLE_EDIT_VEHICLE_DATA)
+                    && roleAssignment.getEntityClassifications() != null) {  // Maybe return also "read" or "delete"? Review this later on, for now only "edit" is needed.
                 List<String> dataOwnersAllowed = roleAssignment.getEntityClassifications().get(CLASSIFICATION_DATA_OWNER);
                 if(dataOwnersAllowed != null) {
                     organisationRefs.addAll(dataOwnersAllowed.stream().map(dataOwner -> dataOwner.replace("/", ":")).toList());

--- a/sobek-service/src/main/java/org/rutebanken/sobek/auth/DefaultAuthorizationService.java
+++ b/sobek-service/src/main/java/org/rutebanken/sobek/auth/DefaultAuthorizationService.java
@@ -102,6 +102,8 @@ public class DefaultAuthorizationService implements AuthorizationService {
 
     @Override
     public List<String> getOrganisationRefsUserIsAuthorizedFor() {
+        if(!authorizationEnabled) { return null; }
+
         List<RoleAssignment> roleAssignments = roleAssignmentExtractor.getRoleAssignmentsForUser();
 
         Set<String> organisationRefs = new HashSet<>();

--- a/sobek-service/src/main/java/org/rutebanken/sobek/auth/DefaultAuthorizationService.java
+++ b/sobek-service/src/main/java/org/rutebanken/sobek/auth/DefaultAuthorizationService.java
@@ -14,8 +14,8 @@ import java.util.Collection;
 import java.util.List;
 
 import static org.rutebanken.helper.organisation.AuthorizationConstants.ENTITY_CLASSIFIER_ALL_ATTRIBUTES;
-import static org.rutebanken.helper.organisation.AuthorizationConstants.ROLE_DELETE_STOPS;
-import static org.rutebanken.helper.organisation.AuthorizationConstants.ROLE_EDIT_STOPS;
+import static org.rutebanken.sobek.auth.AuthorizationConstants.ROLE_DELETE_VEHICLE_DATA;
+import static org.rutebanken.sobek.auth.AuthorizationConstants.ROLE_EDIT_VEHICLE_DATA;
 
 public class DefaultAuthorizationService implements AuthorizationService {
     private final DataScopedAuthorizationService dataScopedAuthorizationService;
@@ -35,15 +35,13 @@ public class DefaultAuthorizationService implements AuthorizationService {
         if(hasNoAuthentications()) {
             return false;
         }
-        // For now, if the user is authenticated, we assume they can edit all entities.
-        return true;
-        // return verifyCanEditAllEntities(roleAssignmentExtractor.getRoleAssignmentsForUser());
+        return verifyCanEditAllEntities(roleAssignmentExtractor.getRoleAssignmentsForUser());
     }
 
     boolean verifyCanEditAllEntities(List<RoleAssignment> roleAssignments) {
         return roleAssignments
                 .stream()
-                .anyMatch(roleAssignment -> ROLE_EDIT_STOPS.equals(roleAssignment.getRole())
+                .anyMatch(roleAssignment -> ROLE_EDIT_VEHICLE_DATA.equals(roleAssignment.getRole())
                                              && roleAssignment.getEntityClassifications() != null
                                              && roleAssignment.getEntityClassifications().get(AuthorizationConstants.ENTITY_TYPE) != null
                                              && roleAssignment.getEntityClassifications().get(AuthorizationConstants.ENTITY_TYPE).contains(ENTITY_CLASSIFIER_ALL_ATTRIBUTES)
@@ -53,35 +51,28 @@ public class DefaultAuthorizationService implements AuthorizationService {
 
     @Override
     public boolean canEditEntities(Collection<? extends EntityStructure> entities) {
-        // For now, if the user is authenticated, we assume they can edit all entities.
-        return true;
-        //return dataScopedAuthorizationService.isAuthorized(ROLE_EDIT_STOPS, entities);
+        return dataScopedAuthorizationService.isAuthorized(ROLE_EDIT_VEHICLE_DATA, entities);
     }
 
 
     @Override
     public void verifyCanEditEntities(Collection<? extends EntityStructure> entities) {
-        // For now, if the user is authenticated, we assume they can edit all entities.
-        return;
-//        dataScopedAuthorizationService.assertAuthorized(ROLE_EDIT_STOPS, entities);
+        dataScopedAuthorizationService.assertAuthorized(ROLE_EDIT_VEHICLE_DATA, entities);
     }
 
     @Override
     public void verifyCanDeleteEntities(Collection<? extends EntityStructure> entities) {
-        // For now, if the user is authenticated, we assume they can edit all entities.
-        return;
-//        dataScopedAuthorizationService.assertAuthorized(ROLE_DELETE_STOPS, entities);
-
+        dataScopedAuthorizationService.assertAuthorized(ROLE_DELETE_VEHICLE_DATA, entities);
     }
 
     @Override
     public boolean canDeleteEntity(EntityStructure entity) {
-        return canEditDeleteEntity(entity, ROLE_DELETE_STOPS);
+        return canEditDeleteEntity(entity, ROLE_DELETE_VEHICLE_DATA);
     }
 
     @Override
     public boolean canEditEntity(EntityStructure entity) {
-        return canEditDeleteEntity(entity, ROLE_EDIT_STOPS);
+        return canEditDeleteEntity(entity, ROLE_EDIT_VEHICLE_DATA);
     }
 
     @Override

--- a/sobek-service/src/main/java/org/rutebanken/sobek/auth/DefaultAuthorizationService.java
+++ b/sobek-service/src/main/java/org/rutebanken/sobek/auth/DefaultAuthorizationService.java
@@ -11,11 +11,12 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import static org.rutebanken.helper.organisation.AuthorizationConstants.ENTITY_CLASSIFIER_ALL_ATTRIBUTES;
-import static org.rutebanken.sobek.auth.AuthorizationConstants.ROLE_DELETE_VEHICLE_DATA;
-import static org.rutebanken.sobek.auth.AuthorizationConstants.ROLE_EDIT_VEHICLE_DATA;
+import static org.rutebanken.sobek.auth.AuthorizationConstants.*;
 
 public class DefaultAuthorizationService implements AuthorizationService {
     private final DataScopedAuthorizationService dataScopedAuthorizationService;
@@ -98,4 +99,21 @@ public class DefaultAuthorizationService implements AuthorizationService {
 
         return dataScopedAuthorizationService.isAuthorized(role, List.of(entity));
     }
+
+    @Override
+    public List<String> getOrganisationRefsUserIsAuthorizedFor() {
+        List<RoleAssignment> roleAssignments = roleAssignmentExtractor.getRoleAssignmentsForUser();
+
+        Set<String> organisationRefs = new HashSet<>();
+        roleAssignments.forEach(roleAssignment -> {
+            if(roleAssignment.getRole().equals(ROLE_EDIT_VEHICLE_DATA)) {  // Maybe return also "read" or "delete"? Review this later on, for now only "edit" is needed.
+                List<String> dataOwnersAllowed = roleAssignment.getEntityClassifications().get(CLASSIFICATION_DATA_OWNER);
+                if(dataOwnersAllowed != null) {
+                    organisationRefs.addAll(dataOwnersAllowed.stream().map(dataOwner -> dataOwner.replace("/", ":")).toList());
+                }
+            }
+        });
+        return organisationRefs.stream().toList();
+    }
+
 }

--- a/sobek-service/src/main/java/org/rutebanken/sobek/importer/PublicationDeliveryImporter.java
+++ b/sobek-service/src/main/java/org/rutebanken/sobek/importer/PublicationDeliveryImporter.java
@@ -29,7 +29,6 @@ import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 
 import java.util.Timer;
@@ -50,8 +49,6 @@ public class PublicationDeliveryImporter {
     private final DeckPlanImportHandler deckPlanImportHandler;
     private final EquipmentImportHandler equipmentImportHandler;
     private final VehicleModelImportHandler vehicleModelImportHandler;
-    private final AuthorizationService authorizationService;
-    private final boolean authorizationEnabled;
     private final SchematicMapImportHandler schematicMapImportHandler;
     private final MappingContext mappingContext;
 
@@ -59,8 +56,7 @@ public class PublicationDeliveryImporter {
     public PublicationDeliveryImporter(PublicationDeliveryHelper publicationDeliveryHelper,
                                        PublicationDeliveryCreator publicationDeliveryCreator,
                                        VehicleImportHandler vehicleImportHandler, VehicleTypeImportHandler vehicleTypeImportHandler, DeckPlanImportHandler deckPlanImportHandler, EquipmentImportHandler equipmentImportHandler, VehicleModelImportHandler vehicleModelImportHandler,
-                                       AuthorizationService authorizationService,
-                                       @Value("${authorization.enabled:true}") boolean authorizationEnabled, SchematicMapImportHandler schematicMapImportHandler, MappingContext mappingContext) {
+                                        SchematicMapImportHandler schematicMapImportHandler, MappingContext mappingContext) {
         this.publicationDeliveryHelper = publicationDeliveryHelper;
         this.publicationDeliveryCreator = publicationDeliveryCreator;
         this.vehicleImportHandler = vehicleImportHandler;
@@ -68,16 +64,10 @@ public class PublicationDeliveryImporter {
         this.deckPlanImportHandler = deckPlanImportHandler;
         this.equipmentImportHandler = equipmentImportHandler;
         this.vehicleModelImportHandler = vehicleModelImportHandler;
-        this.authorizationService = authorizationService;
-        this.authorizationEnabled = authorizationEnabled;
         this.schematicMapImportHandler = schematicMapImportHandler;
         this.mappingContext = mappingContext;
     }
 
-
-    public PublicationDeliveryStructure importPublicationDelivery(PublicationDeliveryStructure incomingPublicationDelivery) {
-        return importPublicationDelivery(incomingPublicationDelivery, null);
-    }
 
     public PublicationDeliveryStructure importPublicationDelivery(PublicationDeliveryStructure incomingPublicationDelivery, ImportParams importParams) {
 //        if(authorizationEnabled && !authorizationService.canEditAllEntities()){

--- a/sobek-service/src/main/java/org/rutebanken/sobek/importer/PublicationDeliveryImporter.java
+++ b/sobek-service/src/main/java/org/rutebanken/sobek/importer/PublicationDeliveryImporter.java
@@ -17,7 +17,6 @@ package org.rutebanken.sobek.importer;
 
 import org.rutebanken.netex.model.PublicationDeliveryStructure;
 import org.rutebanken.netex.model.ResourceFrame;
-import org.rutebanken.sobek.auth.AuthorizationService;
 import org.rutebanken.sobek.exporter.PublicationDeliveryCreator;
 import org.rutebanken.sobek.importer.handler.*;
 import org.rutebanken.sobek.importer.log.ImportLogger;
@@ -28,7 +27,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.util.Timer;

--- a/sobek-service/src/main/java/org/rutebanken/sobek/importer/PublicationDeliveryImporter.java
+++ b/sobek-service/src/main/java/org/rutebanken/sobek/importer/PublicationDeliveryImporter.java
@@ -80,9 +80,9 @@ public class PublicationDeliveryImporter {
     }
 
     public PublicationDeliveryStructure importPublicationDelivery(PublicationDeliveryStructure incomingPublicationDelivery, ImportParams importParams) {
-        if(authorizationEnabled && !authorizationService.canEditAllEntities()){
-            throw new AccessDeniedException("Insufficient privileges for operation");
-        }
+//        if(authorizationEnabled && !authorizationService.canEditAllEntities()){
+//            throw new AccessDeniedException("Insufficient privileges for operation");
+//        }
 
 
         if (incomingPublicationDelivery.getDataObjects() == null) {

--- a/sobek-service/src/main/java/org/rutebanken/sobek/importer/PublicationDeliveryImporter.java
+++ b/sobek-service/src/main/java/org/rutebanken/sobek/importer/PublicationDeliveryImporter.java
@@ -111,7 +111,7 @@ public class PublicationDeliveryImporter {
         // Currently only supporting one resource frame per publication delivery
         ResourceFrame netexResourceFrame = publicationDeliveryHelper.findResourceFrame(incomingPublicationDelivery);
 
-        mappingContext.updateMappingContext(incomingPublicationDelivery);
+        mappingContext.updateMappingContext(incomingPublicationDelivery, netexResourceFrame);
 
         ResourceFrame responseResourceFrame = null;
         if(netexResourceFrame != null) {

--- a/sobek-service/src/main/java/org/rutebanken/sobek/importer/PublicationDeliveryImporter.java
+++ b/sobek-service/src/main/java/org/rutebanken/sobek/importer/PublicationDeliveryImporter.java
@@ -70,10 +70,6 @@ public class PublicationDeliveryImporter {
 
 
     public PublicationDeliveryStructure importPublicationDelivery(PublicationDeliveryStructure incomingPublicationDelivery, ImportParams importParams) {
-//        if(authorizationEnabled && !authorizationService.canEditAllEntities()){
-//            throw new AccessDeniedException("Insufficient privileges for operation");
-//        }
-
 
         if (incomingPublicationDelivery.getDataObjects() == null) {
             String responseMessage = "Received publication delivery but it does not contain any data objects.";

--- a/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/context/MappingContext.java
+++ b/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/context/MappingContext.java
@@ -106,7 +106,7 @@ public class MappingContext {
         logger.info("Setting default time zone for netex mapping context to {}", this.defaultTimeZone);
     }
 
-    public void updateMappingContext(PublicationDeliveryStructure publicationDeliveryStructure) {
+    public void updateMappingContext(PublicationDeliveryStructure publicationDeliveryStructure, ResourceFrame resourceFrame) {
         // Check what kind of frame we find
         List<JAXBElement<? extends Common_VersionFrameStructure>> compositeFrameOrCommonFrame = publicationDeliveryStructure.getDataObjects().getCompositeFrameOrCommonFrame();
 
@@ -127,6 +127,47 @@ public class MappingContext {
         String timeZoneString = defaults.getDefaultLocale().getTimeZone();
 
         this.defaultTimeZone = ZoneId.of(timeZoneString);
+
+        ResponsibilitySetsInFrame_RelStructure responsibilitySets = resourceFrame.getResponsibilitySets();
+
+        if (responsibilitySets == null || responsibilitySets.getResponsibilitySet() == null) {
+            throw new NetexMappingException("Cannot resolve responsibilitysets from resourceframe " + resourceFrame.getId());
+        }
+
+        ResponsibilitySet responsibilitySet = responsibilitySets.getResponsibilitySet().getFirst();
+        if (responsibilitySet == null) {
+            throw new NetexMappingException("Cannot resolve responsibilityset from resourceframe " + resourceFrame.getId());
+        }
+
+        if(responsibilitySet.getRoles() == null ||
+                responsibilitySet.getRoles().getResponsibilityRoleAssignment() == null ||
+                responsibilitySet.getRoles().getResponsibilityRoleAssignment().isEmpty()) {
+            throw new NetexMappingException("Cannot resolve role from responsibilityset " + responsibilitySet.getId());
+        }
+
+        ResponsibilityRoleAssignment roleAssignment = responsibilitySet.getRoles()
+                                .getResponsibilityRoleAssignment()
+                                .stream()
+                                .filter(ra -> ra.getDataRoleType().contains(DataRoleTypeEnumeration.OWNS))
+                                .findFirst()
+                                .orElseThrow(() -> new NetexMappingException("Cannot resolve dataowner role from responsibilityset " + responsibilitySet.getId()));
+
+        if(roleAssignment.getResponsibleOrganisationRef() == null || roleAssignment.getResponsibleOrganisationRef().getRef() == null) {
+            throw new NetexMappingException("Cannot resolve responsible organisation from responsibilityset " + responsibilitySet.getId());
+        }
+
+        if(defaults.getDefaultResponsibilitySetRef() == null || defaults.getDefaultResponsibilitySetRef().getRef() == null) {
+            throw new NetexMappingException("Cannot resolve default responsibilityset from FrameDefaults");
+        }
+
+        if(!responsibilitySet.getId().equals(defaults.getDefaultResponsibilitySetRef().getRef())) {
+            throw new NetexMappingException("Default responsibilitysetref " + defaults.getDefaultResponsibilitySetRef().getRef() + " doesn't match to a valid responsibilityset");
+        }
+
+        this.ownedEntityMapper.setDataOwnerRef(roleAssignment.getResponsibleOrganisationRef().getRef());
+
+
+
         logger.info("Setting default time zone for netex mapping context to {}", this.defaultTimeZone);
     }
 }

--- a/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/context/MappingContext.java
+++ b/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/context/MappingContext.java
@@ -95,17 +95,6 @@ public class MappingContext {
         this.ownedEntityMapper = ownedEntityMapper;
     }
 
-    public void updateMappingContext(SiteFrame netexSiteFrame) {
-        String timeZoneString = Optional.of(netexSiteFrame)
-                .map(SiteFrame::getFrameDefaults)
-                .map(VersionFrameDefaultsStructure::getDefaultLocale)
-                .map(LocaleStructure::getTimeZone)
-                .orElseThrow(() -> new NetexMappingException("Cannot resolve time zone from FrameDefaults in site frame " + netexSiteFrame.getId()));
-
-        this.defaultTimeZone = ZoneId.of(timeZoneString);
-        logger.info("Setting default time zone for netex mapping context to {}", this.defaultTimeZone);
-    }
-
     public void updateMappingContext(PublicationDeliveryStructure publicationDeliveryStructure, ResourceFrame resourceFrame) {
         // Check what kind of frame we find
         List<JAXBElement<? extends Common_VersionFrameStructure>> compositeFrameOrCommonFrame = publicationDeliveryStructure.getDataObjects().getCompositeFrameOrCommonFrame();

--- a/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/context/MappingContext.java
+++ b/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/context/MappingContext.java
@@ -126,7 +126,9 @@ public class MappingContext {
 
         ResponsibilitySetsInFrame_RelStructure responsibilitySets = resourceFrame.getResponsibilitySets();
 
-        if (responsibilitySets == null || responsibilitySets.getResponsibilitySet() == null) {
+        if (responsibilitySets == null ||
+                responsibilitySets.getResponsibilitySet() == null ||
+                responsibilitySets.getResponsibilitySet().isEmpty()) {
             throw new NetexMappingException("Cannot resolve responsibilitysets from resourceframe " + resourceFrame.getId());
         }
 

--- a/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/context/MappingContext.java
+++ b/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/context/MappingContext.java
@@ -58,6 +58,7 @@ public class MappingContext {
     private NetexIdHelper netexIdHelper;
     private DataManagedObjectStructureMapper dataManagedObjectStructureMapper;
     private OwnedEntityMapper ownedEntityMapper;
+    private String dataOwnerRef;
 
     public MappingContext() {
     }
@@ -109,7 +110,9 @@ public class MappingContext {
             throw new NetexMappingException("Cannot resolve time zone from FrameDefaults in frame " + compositeFrameOrCommonFrame.getFirst().getValue().getId());
         }
 
-        if(defaults == null) {
+        if(defaults == null ||
+                defaults.getDefaultLocale() == null ||
+                defaults.getDefaultLocale().getTimeZone() == null) {
             throw new NetexMappingException("Cannot resolve time zone from FrameDefaults in frame " + compositeFrameOrCommonFrame.getFirst().getValue().getId());
         }
 
@@ -153,7 +156,7 @@ public class MappingContext {
             throw new NetexMappingException("Default responsibilitysetref " + defaults.getDefaultResponsibilitySetRef().getRef() + " doesn't match to a valid responsibilityset");
         }
 
-        this.ownedEntityMapper.setDataOwnerRef(roleAssignment.getResponsibleOrganisationRef().getRef());
+        this.setDataOwnerRef(roleAssignment.getResponsibleOrganisationRef().getRef());
 
 
 

--- a/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/context/MappingContext.java
+++ b/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/context/MappingContext.java
@@ -120,6 +120,10 @@ public class MappingContext {
 
         this.defaultTimeZone = ZoneId.of(timeZoneString);
 
+        if(resourceFrame == null) {
+            throw new NetexMappingException("There is no ResourceFrame in the publication delivery");
+        }
+
         ResponsibilitySetsInFrame_RelStructure responsibilitySets = resourceFrame.getResponsibilitySets();
 
         if (responsibilitySets == null || responsibilitySets.getResponsibilitySet() == null) {

--- a/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/context/MappingContext.java
+++ b/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/context/MappingContext.java
@@ -12,6 +12,7 @@ import org.rutebanken.sobek.netex.id.ValidPrefixList;
 import org.rutebanken.sobek.netex.mapping.NetexMappingException;
 import org.rutebanken.sobek.netex.mapping.mapstruct.DataManagedObjectStructureMapper;
 import org.rutebanken.sobek.netex.mapping.mapstruct.KeyListStructureMapper;
+import org.rutebanken.sobek.netex.mapping.mapstruct.OwnedEntityMapper;
 import org.rutebanken.sobek.netex.mapping.mapstruct.deckplan.DeckSpaceMapper;
 import org.rutebanken.sobek.netex.mapping.mapstruct.deckplan.SpotAffinityMapper;
 import org.rutebanken.sobek.netex.mapping.mapstruct.equipment.*;
@@ -56,6 +57,7 @@ public class MappingContext {
     private ValidPrefixList validPrefixList;
     private NetexIdHelper netexIdHelper;
     private DataManagedObjectStructureMapper dataManagedObjectStructureMapper;
+    private OwnedEntityMapper ownedEntityMapper;
 
     public MappingContext() {
     }
@@ -74,7 +76,8 @@ public class MappingContext {
                           SpotAffinityMapper spotAffinityMapper,
                           ValidPrefixList validPrefixList,
                           NetexIdHelper netexIdHelper,
-                          DataManagedObjectStructureMapper dataManagedObjectStructureMapper) {
+                          DataManagedObjectStructureMapper dataManagedObjectStructureMapper,
+                          OwnedEntityMapper ownedEntityMapper) {
         this.referenceResolver = resolver;
         this.seatEquipmentMapper = seatEquipmentMapper;
         this.bedEquipmentMapper = bedEquipmentMapper;
@@ -89,6 +92,7 @@ public class MappingContext {
         this.validPrefixList = validPrefixList;
         this.netexIdHelper = netexIdHelper;
         this.dataManagedObjectStructureMapper = dataManagedObjectStructureMapper;
+        this.ownedEntityMapper = ownedEntityMapper;
     }
 
     public void updateMappingContext(SiteFrame netexSiteFrame) {

--- a/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/mapstruct/OwnedEntityMapper.java
+++ b/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/mapstruct/OwnedEntityMapper.java
@@ -1,7 +1,5 @@
 package org.rutebanken.sobek.netex.mapping.mapstruct;
 
-import org.mapstruct.Context;
-import org.mapstruct.MappingTarget;
 import org.rutebanken.sobek.model.authorization.OwnedEntity;
 import org.rutebanken.sobek.netex.mapping.context.MappingContext;
 import org.springframework.stereotype.Service;
@@ -10,8 +8,8 @@ import org.springframework.stereotype.Service;
 public class OwnedEntityMapper {
 
     public void updateSobekFromNetex(
-            @MappingTarget OwnedEntity target,
-            @Context MappingContext context
+            OwnedEntity target,
+            MappingContext context
     ) {
         if (target != null) {
             target.setDataOwnerRef(context.getDataOwnerRef());

--- a/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/mapstruct/OwnedEntityMapper.java
+++ b/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/mapstruct/OwnedEntityMapper.java
@@ -2,16 +2,11 @@ package org.rutebanken.sobek.netex.mapping.mapstruct;
 
 import lombok.Getter;
 import lombok.Setter;
-import org.mapstruct.Context;
-import org.mapstruct.Mapper;
 import org.mapstruct.MappingTarget;
 import org.rutebanken.sobek.model.authorization.OwnedEntity;
-import org.rutebanken.sobek.netex.mapping.config.SobekMapperConfig;
-import org.rutebanken.sobek.netex.mapping.context.MappingContext;
+import org.springframework.stereotype.Service;
 
-@Mapper(
-        config = SobekMapperConfig.class
-)
+@Service
 @Getter
 @Setter
 public class OwnedEntityMapper {
@@ -19,9 +14,7 @@ public class OwnedEntityMapper {
     private String dataOwnerRef;
 
     public void updateSobekFromNetex(
-            org.rutebanken.netex.model.DataManagedObjectStructure source,
-            @MappingTarget OwnedEntity target,
-            @Context MappingContext context
+            @MappingTarget OwnedEntity target
     ) {
         if (target != null) {
             target.setDataOwnerRef(dataOwnerRef);

--- a/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/mapstruct/OwnedEntityMapper.java
+++ b/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/mapstruct/OwnedEntityMapper.java
@@ -1,5 +1,7 @@
 package org.rutebanken.sobek.netex.mapping.mapstruct;
 
+import lombok.Getter;
+import lombok.Setter;
 import org.mapstruct.Context;
 import org.mapstruct.Mapper;
 import org.mapstruct.MappingTarget;
@@ -10,14 +12,19 @@ import org.rutebanken.sobek.netex.mapping.context.MappingContext;
 @Mapper(
         config = SobekMapperConfig.class
 )
+@Getter
+@Setter
 public class OwnedEntityMapper {
+
+    private String dataOwnerRef;
+
     public void updateSobekFromNetex(
             org.rutebanken.netex.model.DataManagedObjectStructure source,
             @MappingTarget OwnedEntity target,
             @Context MappingContext context
     ) {
         if (target != null) {
-            target.setDataOwnerRef("NOG:Authority:cP4aPiJ7c39");  // Temporary - set all entities to be owned by ATB
+            target.setDataOwnerRef(dataOwnerRef);
         }
     }
 }

--- a/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/mapstruct/OwnedEntityMapper.java
+++ b/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/mapstruct/OwnedEntityMapper.java
@@ -1,23 +1,20 @@
 package org.rutebanken.sobek.netex.mapping.mapstruct;
 
-import lombok.Getter;
-import lombok.Setter;
+import org.mapstruct.Context;
 import org.mapstruct.MappingTarget;
 import org.rutebanken.sobek.model.authorization.OwnedEntity;
+import org.rutebanken.sobek.netex.mapping.context.MappingContext;
 import org.springframework.stereotype.Service;
 
 @Service
-@Getter
-@Setter
 public class OwnedEntityMapper {
 
-    private String dataOwnerRef;
-
     public void updateSobekFromNetex(
-            @MappingTarget OwnedEntity target
+            @MappingTarget OwnedEntity target,
+            @Context MappingContext context
     ) {
         if (target != null) {
-            target.setDataOwnerRef(dataOwnerRef);
+            target.setDataOwnerRef(context.getDataOwnerRef());
         }
     }
 }

--- a/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/mapstruct/OwnedEntityMapper.java
+++ b/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/mapstruct/OwnedEntityMapper.java
@@ -1,0 +1,23 @@
+package org.rutebanken.sobek.netex.mapping.mapstruct;
+
+import org.mapstruct.Context;
+import org.mapstruct.Mapper;
+import org.mapstruct.MappingTarget;
+import org.rutebanken.sobek.model.authorization.OwnedEntity;
+import org.rutebanken.sobek.netex.mapping.config.SobekMapperConfig;
+import org.rutebanken.sobek.netex.mapping.context.MappingContext;
+
+@Mapper(
+        config = SobekMapperConfig.class
+)
+public class OwnedEntityMapper {
+    public void updateSobekFromNetex(
+            org.rutebanken.netex.model.DataManagedObjectStructure source,
+            @MappingTarget OwnedEntity target,
+            @Context MappingContext context
+    ) {
+        if (target != null) {
+            target.setDataOwnerRef("NOG:Authority:cP4aPiJ7c39");  // Temporary - set all entities to be owned by ATB
+        }
+    }
+}

--- a/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/mapstruct/VehicleMapper.java
+++ b/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/mapstruct/VehicleMapper.java
@@ -125,6 +125,7 @@ public interface VehicleMapper {
                 target.setVehicleModel(vehicleModel);
             }
         }
+        context.getOwnedEntityMapper().updateSobekFromNetex(source, target, context);
     }
 
     /**

--- a/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/mapstruct/VehicleMapper.java
+++ b/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/mapstruct/VehicleMapper.java
@@ -125,7 +125,7 @@ public interface VehicleMapper {
                 target.setVehicleModel(vehicleModel);
             }
         }
-        context.getOwnedEntityMapper().updateSobekFromNetex(source, target, context);
+        context.getOwnedEntityMapper().updateSobekFromNetex(target);
     }
 
     /**

--- a/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/mapstruct/VehicleMapper.java
+++ b/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/mapstruct/VehicleMapper.java
@@ -125,7 +125,7 @@ public interface VehicleMapper {
                 target.setVehicleModel(vehicleModel);
             }
         }
-        context.getOwnedEntityMapper().updateSobekFromNetex(target);
+        context.getOwnedEntityMapper().updateSobekFromNetex(target, context);
     }
 
     /**

--- a/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/mapstruct/VehicleTypeMapper.java
+++ b/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/mapstruct/VehicleTypeMapper.java
@@ -102,7 +102,7 @@ public interface VehicleTypeMapper {
                 target.setDeckPlan(deckPlan);
             }
         }
-        context.getOwnedEntityMapper().updateSobekFromNetex(target);
+        context.getOwnedEntityMapper().updateSobekFromNetex(target, context);
     }
 
     /**

--- a/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/mapstruct/VehicleTypeMapper.java
+++ b/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/mapstruct/VehicleTypeMapper.java
@@ -102,7 +102,7 @@ public interface VehicleTypeMapper {
                 target.setDeckPlan(deckPlan);
             }
         }
-        context.getOwnedEntityMapper().updateSobekFromNetex(source, target, context);
+        context.getOwnedEntityMapper().updateSobekFromNetex(target);
     }
 
     /**

--- a/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/mapstruct/VehicleTypeMapper.java
+++ b/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/mapstruct/VehicleTypeMapper.java
@@ -102,6 +102,7 @@ public interface VehicleTypeMapper {
                 target.setDeckPlan(deckPlan);
             }
         }
+        context.getOwnedEntityMapper().updateSobekFromNetex(source, target, context);
     }
 
     /**

--- a/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/mapstruct/deckplan/DeckPlanMapper.java
+++ b/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/mapstruct/deckplan/DeckPlanMapper.java
@@ -66,6 +66,7 @@ public interface DeckPlanMapper {
         if(target != null) {
             context.getDataManagedObjectStructureMapper().afterMappingToSobek(source, target, context);
         }
+        context.getOwnedEntityMapper().updateSobekFromNetex(source, target, context);
     }
 
     /**

--- a/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/mapstruct/deckplan/DeckPlanMapper.java
+++ b/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/mapstruct/deckplan/DeckPlanMapper.java
@@ -66,7 +66,7 @@ public interface DeckPlanMapper {
         if(target != null) {
             context.getDataManagedObjectStructureMapper().afterMappingToSobek(source, target, context);
         }
-        context.getOwnedEntityMapper().updateSobekFromNetex(source, target, context);
+        context.getOwnedEntityMapper().updateSobekFromNetex(target);
     }
 
     /**

--- a/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/mapstruct/deckplan/DeckPlanMapper.java
+++ b/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/mapstruct/deckplan/DeckPlanMapper.java
@@ -66,7 +66,7 @@ public interface DeckPlanMapper {
         if(target != null) {
             context.getDataManagedObjectStructureMapper().afterMappingToSobek(source, target, context);
         }
-        context.getOwnedEntityMapper().updateSobekFromNetex(target);
+        context.getOwnedEntityMapper().updateSobekFromNetex(target, context);
     }
 
     /**

--- a/sobek-service/src/test/java/org/rutebanken/sobek/auth/DummyAuthorizationService.java
+++ b/sobek-service/src/test/java/org/rutebanken/sobek/auth/DummyAuthorizationService.java
@@ -4,6 +4,7 @@ import org.rutebanken.sobek.model.EntityStructure;
 import org.springframework.stereotype.Service;
 
 import java.util.Collection;
+import java.util.List;
 
 @Service
 public class DummyAuthorizationService implements AuthorizationService {
@@ -41,4 +42,8 @@ public class DummyAuthorizationService implements AuthorizationService {
     public boolean isGuest() {
         return false;
     }
+
+    @Override
+    public List<String> getOrganisationRefsUserIsAuthorizedFor() { return null; }
+
 }

--- a/sobek-service/src/test/java/org/rutebanken/sobek/netex/mapping/mapstruct/VehicleMapperTest.java
+++ b/sobek-service/src/test/java/org/rutebanken/sobek/netex/mapping/mapstruct/VehicleMapperTest.java
@@ -58,6 +58,7 @@ class VehicleMapperTest {
 
         VehicleType mockVehicleType = new VehicleType();
         mockVehicleType.setNetexId("NMR:VehicleType:1");
+        mockVehicleType.setDataOwnerRef("NOG:Authority:1");
 
         ReferenceResolver referenceResolver = mock(ReferenceResolver.class);
         when(referenceResolver.resolve(any(),any(),eq(VehicleType.class))).thenReturn(mockVehicleType);

--- a/sobek-service/src/test/java/org/rutebanken/sobek/netex/mapping/mapstruct/VehicleMapperTest.java
+++ b/sobek-service/src/test/java/org/rutebanken/sobek/netex/mapping/mapstruct/VehicleMapperTest.java
@@ -42,6 +42,8 @@ class VehicleMapperTest {
     private ValidPrefixList validPrefixList;
     @Autowired
     private DataManagedObjectStructureMapper dataManagedObjectStructureMapper;
+    @Autowired
+    private OwnedEntityMapper ownedEntityMapper;
 
     @Test
     void testMapperIsInjected() {
@@ -66,6 +68,7 @@ class VehicleMapperTest {
         mappingContext.setNetexIdHelper(netexIdHelper);
         mappingContext.setValidPrefixList(validPrefixList);
         mappingContext.setDataManagedObjectStructureMapper(dataManagedObjectStructureMapper);
+        mappingContext.setOwnedEntityMapper(ownedEntityMapper);
     }
 
     @Test

--- a/sobek-service/src/test/java/org/rutebanken/sobek/netex/mapping/mapstruct/VehicleMapperTest.java
+++ b/sobek-service/src/test/java/org/rutebanken/sobek/netex/mapping/mapstruct/VehicleMapperTest.java
@@ -69,6 +69,7 @@ class VehicleMapperTest {
         mappingContext.setValidPrefixList(validPrefixList);
         mappingContext.setDataManagedObjectStructureMapper(dataManagedObjectStructureMapper);
         mappingContext.setOwnedEntityMapper(ownedEntityMapper);
+        mappingContext.setDataOwnerRef("NOG:Authority:1");
     }
 
     @Test
@@ -105,6 +106,7 @@ class VehicleMapperTest {
         assertEquals("CHASSIS123", sobekVehicle.getChassisNumber());
         assertEquals("OP456", sobekVehicle.getOperationalNumber());
         assertEquals(temporalTypeMapper.localDateTimeToInstant(LocalDateTime.of(2023, 1, 15, 0, 0)), sobekVehicle.getRegistrationDate());
+        assertEquals("NOG:Authority:1", sobekVehicle.getDataOwnerRef());
 
         // Check that references are stored in transient fields
         assertNotNull(sobekVehicle.getVehicleModel());
@@ -112,6 +114,7 @@ class VehicleMapperTest {
 
         assertNotNull(sobekVehicle.getTransportType());
         assertEquals("NMR:VehicleType:1", sobekVehicle.getTransportType().getNetexId());
+        assertEquals("NOG:Authority:1", sobekVehicle.getTransportType().getDataOwnerRef());
     }
 
     @Test


### PR DESCRIPTION
### Summary

Add support for Organisations in Sobek:
- Update the GraphQL organisations endpoint 
- Let Vehicle, VehicleType (and Train) and DeckPlan have a DataOwnerRef property, that maps them to an organisation that "owns" that data
- Add authorization checks to save operations, so that the system verifies that the user has authorization to edit the given data
- Update integration test to use the structure about how organization data may be provided as part of the NeTEx XML

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to documentation only)
- [ ] Other (please describe)

### Issue

#111 
#109 