### PR TITLE
Publish GraphQL schema via GitHub Pages (closes #133)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,47 @@
+name: Publish schema docs
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'sobek-app/src/main/resources/graphql/schema.graphqls'
+      - 'docs/**'
+      - '.github/workflows/docs.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+      - name: Assemble site
+        run: |
+          mkdir -p _site
+          cp docs/index.html _site/index.html
+          cp sobek-app/src/main/resources/graphql/schema.graphqls _site/schema.graphqls
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+
+  deploy:
+    if: github.repository_owner == 'entur'
+    needs: build
+    runs-on: ubuntu-24.04
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -418,6 +418,13 @@ Tip: GraphiQL UI available on https://api.dev.entur.io/graphql-explorer/vehicles
 https://github.com/graphql/graphiql
 (Use e.g. `Modify Headers` for Chrome to add bearer-token for mutations)
 
+### Schema file
+The current GraphQL schema (`schema.graphqls`) is published to GitHub Pages
+on every change merged to `main`:
+https://entur.github.io/sobek/
+
+Use it for client codegen, IDE tooling and drift checks.
+
 ## Flyway
 To create the database for sobek, download and use the flyway command line tool:
 https://flywaydb.org/documentation/commandline/

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,136 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>Sobek GraphQL schema</title>
+  <style>
+    :root { color-scheme: light dark; }
+
+    *, *::before, *::after { box-sizing: border-box; }
+
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: grid;
+      place-items: center;
+      padding: 2rem;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+      line-height: 1.6;
+      background:
+        radial-gradient(circle at 15% 0%, rgba(225, 0, 152, 0.10), transparent 55%),
+        radial-gradient(circle at 85% 100%, rgba(225, 0, 152, 0.08), transparent 55%);
+    }
+
+    .card {
+      max-width: 580px;
+      width: 100%;
+      padding: 2.5rem 2.25rem;
+      background: light-dark(#ffffff, #1a1a1a);
+      border: 1px solid light-dark(#e6e6e6, #2a2a2a);
+      border-radius: 14px;
+      box-shadow:
+        0 1px 2px rgba(0, 0, 0, 0.04),
+        0 10px 40px rgba(0, 0, 0, 0.08);
+      text-align: center;
+    }
+
+    .logo {
+      width: 84px;
+      height: 84px;
+      margin: 0 auto 1.5rem;
+      display: block;
+    }
+
+    h1 {
+      margin: 0 0 1.25rem;
+      font-size: 1.75rem;
+      font-weight: 600;
+      letter-spacing: -0.01em;
+      color: light-dark(#161616, #f4f4f4);
+    }
+
+    p {
+      margin: 0 0 1rem;
+      color: light-dark(#444, #b8b8b8);
+      text-align: left;
+    }
+
+    code {
+      background: light-dark(#f3f3f3, #262626);
+      padding: 0.1em 0.4em;
+      border-radius: 4px;
+      font-size: 0.92em;
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    }
+
+    .download {
+      display: inline-block;
+      margin-top: 1.5rem;
+      padding: 0.8rem 2rem;
+      background: #e10098;
+      color: #ffffff;
+      text-decoration: none;
+      border-radius: 8px;
+      font-weight: 600;
+      letter-spacing: 0.01em;
+      transition: background 0.15s ease, transform 0.1s ease, box-shadow 0.15s ease;
+      box-shadow: 0 4px 14px rgba(225, 0, 152, 0.35);
+    }
+
+    .download:hover { background: #c00084; }
+    .download:active { transform: translateY(1px); box-shadow: 0 2px 8px rgba(225, 0, 152, 0.30); }
+    .download:focus-visible { outline: 3px solid #e10098; outline-offset: 3px; }
+
+    footer {
+      margin-top: 2rem;
+      font-size: 0.85rem;
+      color: light-dark(#888, #777);
+    }
+
+    footer a {
+      color: inherit;
+      text-decoration: underline;
+      text-underline-offset: 2px;
+    }
+  </style>
+</head>
+<body>
+  <main class="card">
+    <svg class="logo" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400" aria-label="GraphQL logo">
+      <g fill="none" stroke="#e10098" stroke-width="11" stroke-linejoin="round">
+        <polygon points="200,30 348,115 348,285 200,370 52,285 52,115"/>
+        <polygon points="200,30 348,285 52,285"/>
+        <polygon points="200,370 348,115 52,115"/>
+      </g>
+      <g fill="#e10098">
+        <circle cx="200" cy="30"  r="18"/>
+        <circle cx="348" cy="115" r="18"/>
+        <circle cx="348" cy="285" r="18"/>
+        <circle cx="200" cy="370" r="18"/>
+        <circle cx="52"  cy="285" r="18"/>
+        <circle cx="52"  cy="115" r="18"/>
+      </g>
+    </svg>
+
+    <h1>Sobek GraphQL schema</h1>
+
+    <p>
+      This page hosts the current GraphQL schema for <strong>Sobek</strong>,
+      Entur's national vehicle register
+      (<em>Nasjonalt materiellregister</em>).
+    </p>
+    <p>
+      Use <code>schema.graphqls</code> for client codegen, IDE tooling,
+      or schema exploration. The file reflects the latest commit on
+      <code>main</code>.
+    </p>
+
+    <a class="download" href="schema.graphqls" download>Download schema.graphqls</a>
+
+    <footer>
+      Source: <a href="https://github.com/entur/sobek">github.com/entur/sobek</a>
+    </footer>
+  </main>
+</body>
+</html>

--- a/sobek-app/src/main/resources/graphql/schema.graphqls
+++ b/sobek-app/src/main/resources/graphql/schema.graphqls
@@ -1,0 +1,308 @@
+# Custom scalars
+scalar DateTime
+
+# MultilingualString type
+type MultilingualString {
+    value: String
+    lang: String
+}
+
+input MultilingualStringInput {
+    value: String
+    lang: String
+}
+
+# Enums
+enum TransportMode {
+    ALL
+    AIR
+    ANY_MODE
+    BUS
+    CABLEWAY
+    COACH
+    FERRY
+    FUNICULAR
+    INTERCITY_RAIL
+    LIFT
+    METRO
+    OTHER
+    RAIL
+    SELF_DRIVE
+    SNOW_AND_ICE
+    TAXI
+    TRAM
+    TROLLEY_BUS
+    UNKNOWN
+    URBAN_RAIL
+    WATER
+}
+
+enum OrganisationType {
+    AUTHORITY
+    OPERATOR
+    OTHER
+}
+
+enum PropulsionType {
+    COMBUSTION
+    ELECTRIC
+    ELECTRIC_ASSIST
+    HYBRID
+    HUMAN
+    OTHER
+}
+
+enum FuelType {
+    PETROL
+    PETROL_LEADED
+    PETROL_UNLEADED
+    DIESEL
+    ELECTRICITY
+    BATTERY
+    ELECTRIC_CONTACT
+    DIESEL_BATTERY_HYBRID
+    PETROL_BATTERY_HYBRID
+    HYDROGEN
+    BIODIESEL
+    NATURAL_GAS
+    LIQUID_GAS
+    METHANE
+    TPG
+    ETHANOL
+    OTHER
+    NONE
+}
+
+enum HybridCategory {
+    CHARGEABLE
+    NONCHARGEABLE
+}
+
+# Filter inputs
+input VehicleTypeFilter {
+    ids: [String!]
+    transportModes: [TransportMode!]
+}
+
+input VehicleFilter {
+    ids: [String!]
+    transportModes: [TransportMode!]
+}
+
+input OrganisationsFilter {
+    ids: [String!]
+    organisationType: OrganisationType
+}
+
+# Page types
+type Page {
+    page: Int!
+    size: Int!
+    totalElements: Int!
+}
+
+# KeyValues type
+type KeyValues {
+    key: String!
+    values: [String!]!
+}
+input KeyValuesInput {
+    key: String!
+    values: [String!]!
+}
+
+# PrivateCode type
+type PrivateCode {
+    type: String
+    value: String!
+}
+
+input PrivateCodeInput {
+    type: String
+    value: String!
+}
+
+# PassengerCapacity type
+type PassengerCapacity {
+    totalCapacity: Int
+    seatingCapacity: Int
+    standingCapacity: Int
+    pushchairCapacity: Int
+    wheelchairPlaceCapacity: Int
+    pramPlaceCapacity: Int
+    bicycleRackCapacity: Int
+}
+input PassengerCapacityInput {
+    totalCapacity: Int
+    seatingCapacity: Int
+    standingCapacity: Int
+    pushchairCapacity: Int
+    wheelchairPlaceCapacity: Int
+    pramPlaceCapacity: Int
+    bicycleRackCapacity: Int
+}
+
+# DeckPlan type
+type DeckPlan {
+    id: String!
+    name: MultilingualString
+    description: MultilingualString
+    version: String
+    created: DateTime
+    changed: DateTime
+}
+input DeckPlanInput {
+    id: String
+    name: MultilingualStringInput
+    description: MultilingualStringInput
+}
+
+type DeckPlanPage {
+    content: [DeckPlan!]!
+    totalElements: Int!
+    page: Int!
+    size: Int!
+}
+
+# Organisation type
+type Organisation {
+    id: String!
+    name: MultilingualString
+    legalName: String
+    organisationType: OrganisationType
+    companyNumber: String
+    contactDetails: String
+    version: String
+    created: DateTime
+    changed: DateTime
+}
+
+type OrganisationPage {
+    content: [Organisation!]!
+    totalElements: Int!
+    page: Int!
+    size: Int!
+}
+
+# Vehicle
+type Vehicle {
+    id: String!
+    name: MultilingualString
+    description: MultilingualString
+    registrationNumber: String
+    operationalNumber: String
+    transportType: VehicleType
+    chassisNumber: String
+    buildDate: DateTime
+    registrationDate: DateTime
+    version: String
+    created: DateTime
+    changed: DateTime
+    changedBy: String
+}
+
+input VehicleInput {
+    id: String
+    name: MultilingualStringInput
+    description: MultilingualStringInput
+    registrationNumber: String
+    operationalNumber: String
+    transportType: VehicleTypeInput
+    chassisNumber: String
+    buildDate: DateTime
+    registrationDate: DateTime
+}
+
+
+
+type VehiclePage {
+    content: [Vehicle!]!
+    totalElements: Int!
+    page: Int!
+    size: Int!
+}
+
+type VehicleType {
+    id: String!
+    name: MultilingualString
+    shortName: MultilingualString
+    description: MultilingualString
+    euroClass: String
+    propulsionTypes: [PropulsionType]
+    fuelTypes: [FuelType]
+    transportMode: TransportMode
+    passengerCapacity: PassengerCapacity
+    privateCode: PrivateCode
+    keyValues: [KeyValues!]
+    deckPlan: DeckPlan
+    vehicles: [Vehicle!]
+    formDragCoefficient: Float
+    rollResistanceCoefficient: Float
+    maximumEngineEffectKW: Float
+    maximumVelocity: Float
+    maximumRange: Float
+    length: Float
+    height: Float
+    width: Float
+    weight: Float
+    lowFloor: Boolean
+    selfPropelled: Boolean
+    hybridCategory: HybridCategory
+    version: String
+    created: DateTime
+    changed: DateTime
+    changedBy: String
+}
+
+input VehicleTypeInput {
+    id: String
+    name: MultilingualStringInput
+    shortName: MultilingualStringInput
+    description: MultilingualStringInput
+    euroClass: String
+    propulsionTypes: [PropulsionType]
+    fuelTypes: [FuelType]
+    transportMode: TransportMode
+    passengerCapacity: PassengerCapacityInput
+    privateCode: PrivateCodeInput
+    keyValues: [KeyValuesInput!]
+    deckPlan: DeckPlanInput
+    formDragCoefficient: Float
+    rollResistanceCoefficient: Float
+    maximumEngineEffectKW: Float
+    maximumVelocity: Float
+    maximumRange: Float
+    length: Float
+    height: Float
+    width: Float
+    weight: Float
+    lowFloor: Boolean
+    selfPropelled: Boolean
+    hybridCategory: HybridCategory
+}
+
+type VehicleTypePage {
+    content: [VehicleType!]!
+    totalElements: Int!
+    page: Int!
+    size: Int!
+}
+
+# Root query type
+type Query {
+    vehicles(filter: VehicleFilter, page: Int = 0, size: Int = 20): VehiclePage!
+    vehicleTypes(filter: VehicleTypeFilter, page: Int = 0, size: Int = 20): VehicleTypePage!
+    deckPlans(page: Int = 0, size: Int = 20): DeckPlanPage!
+    organisations(filter: OrganisationsFilter, page: Int = 0, size: Int = 20): OrganisationPage!
+}
+
+type Mutation {
+    createOrUpdateVehicle(input: VehicleInput!): String
+    createOrUpdateVehicleType(input: VehicleTypeInput!): String
+    createOrUpdateDeckPlan(input: DeckPlanInput!): String
+}
+
+schema {
+    query: Query
+    mutation: Mutation
+}


### PR DESCRIPTION
## Summary

Closes #133 

- Adds `docs/index.html` — a small landing page with a styled download link and an embedded GraphQL mark
- Adds `.github/workflows/docs.yml` — bundles `sobek-app/src/main/resources/graphql/schema.graphqls` next to `index.html` and deploys via `actions/deploy-pages` on push to `main`
- Commits the initial `schema.graphqls` itself, which had been staged locally but not yet recorded

After merge the site will be live at `https://entur.github.io/sobek/` with the schema available at `https://entur.github.io/sobek/schema.graphqls`.

<img width="627" height="562" alt="Screenshot From 2026-05-26 10-59-00" src="https://github.com/user-attachments/assets/06d22f42-346e-45b7-87ac-8df26a9cbeb2" />

## One-time manual step (org admin)
**Settings → Pages → Source = "GitHub Actions"** must be flipped on `entur/sobek`. The deploy job will fail until this is set. **Done (kjetil)**

## Test plan
- [ ] Lint passes locally (`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/docs.yml'))"`)
- [ ] Open `docs/index.html` locally with a sibling `schema.graphqls` and confirm the link downloads it
- [ ] After Pages source toggle: first run on `main` produces a green `deploy` job with a `page_url` output of `https://entur.github.io/sobek/`
- [ ] Visit the live URL → land on `index.html` → click → browser downloads `schema.graphqls` matching the source file in `sobek-app/`
- [ ] Touch an unrelated file (e.g. `README.md`) on `main` → docs workflow is skipped (paths filter)
- [ ] Touch `schema.graphqls` on `main` → docs workflow runs and republishes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

