### PR TITLE
Feature/add organisation to mutations

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,9 @@ See [Supported Docker Compose Profiles](#supported-docker-compose-profiles) for 
 > **Note!** You must choose at least one of the options from each category below!
 
 > **Note!** `local` profile must always be included!
+> **Note!** You need to define the following environment variables:
+> - `SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_INTERNAL_CLIENT_SECRET`
+> - `SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_INTERNAL_CLIENT_ID`
 
 ##### Storage
 

--- a/sobek-app/src/main/java/org/rutebanken/sobek/auth/check/SobekOriganisationChecker.java
+++ b/sobek-app/src/main/java/org/rutebanken/sobek/auth/check/SobekOriganisationChecker.java
@@ -50,7 +50,7 @@ public class SobekOriganisationChecker implements OrganisationChecker {
                 return dataOwnerClassifications.stream().anyMatch(c -> c.equals(orgRef));
             }
             logger.debug("Org ref is null for entity: {}", entity);
-            return true;
+            return false;
         } else {
             logger.warn("Cannot check for organisation for entity {}", entity);
             return true;

--- a/sobek-app/src/main/java/org/rutebanken/sobek/auth/check/SobekOriganisationChecker.java
+++ b/sobek-app/src/main/java/org/rutebanken/sobek/auth/check/SobekOriganisationChecker.java
@@ -19,6 +19,7 @@ package org.rutebanken.sobek.auth.check;
 import org.rutebanken.helper.organisation.OrganisationChecker;
 import org.rutebanken.helper.organisation.RoleAssignment;
 import org.rutebanken.netex.model.Vehicle;
+import org.rutebanken.sobek.model.authorization.OwnedEntity;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -31,13 +32,11 @@ public class SobekOriganisationChecker implements OrganisationChecker {
     @Override
     public boolean entityMatchesOrganisationRef(RoleAssignment roleAssignment, Object entity) {
 
-        if (entity instanceof Vehicle vehicle) {
-            if (vehicle.getTransportOrganisationRef() != null) {
-                String orgRef = vehicle.getTransportOrganisationRef().getValue().getRef();
-                if (orgRef != null) {
-                    logger.debug("Found org ref {} for entity. Returning true if it matches role assignment organisation :{}", orgRef, roleAssignment.getOrganisation());
-                    return orgRef.endsWith(":" + roleAssignment.getOrganisation());
-                }
+        if (entity instanceof OwnedEntity ownedEntity) {
+            if (ownedEntity.getDataOwnerRef() != null) {
+                String orgRef = ":" + ownedEntity.getDataOwnerRef().replace(":", "/");
+                logger.debug("Found org ref {} for entity. Returning true if the role assignment contains reference to the organisation", orgRef);
+                return roleAssignment.getEntityClassifications().get("Vehicle").stream().anyMatch(c -> c.endsWith(orgRef));
             }
             logger.debug("Org ref is null for entity: {}", entity);
             return true;

--- a/sobek-app/src/main/java/org/rutebanken/sobek/auth/check/SobekOriganisationChecker.java
+++ b/sobek-app/src/main/java/org/rutebanken/sobek/auth/check/SobekOriganisationChecker.java
@@ -34,9 +34,9 @@ public class SobekOriganisationChecker implements OrganisationChecker {
 
         if (entity instanceof OwnedEntity ownedEntity) {
             if (ownedEntity.getDataOwnerRef() != null) {
-                String orgRef = ":" + ownedEntity.getDataOwnerRef().replace(":", "/");
+                String orgRef = ownedEntity.getDataOwnerRef().replace(":", "/");
                 logger.debug("Found org ref {} for entity. Returning true if the role assignment contains reference to the organisation", orgRef);
-                return roleAssignment.getEntityClassifications().get("Vehicle").stream().anyMatch(c -> c.endsWith(orgRef));
+                return roleAssignment.getEntityClassifications().get("DataOwner").stream().anyMatch(c -> c.equals(orgRef));
             }
             logger.debug("Org ref is null for entity: {}", entity);
             return true;

--- a/sobek-app/src/main/java/org/rutebanken/sobek/auth/check/SobekOriganisationChecker.java
+++ b/sobek-app/src/main/java/org/rutebanken/sobek/auth/check/SobekOriganisationChecker.java
@@ -37,7 +37,17 @@ public class SobekOriganisationChecker implements OrganisationChecker {
             if (ownedEntity.getDataOwnerRef() != null) {
                 String orgRef = ownedEntity.getDataOwnerRef().replace(":", "/");
                 logger.debug("Found org ref {} for entity. Returning true if the role assignment contains reference to the organisation", orgRef);
-                return roleAssignment.getEntityClassifications().get(CLASSIFICATION_DATA_OWNER).stream().anyMatch(c -> c.equals(orgRef));
+                var entityClassifications = roleAssignment.getEntityClassifications();
+                if (entityClassifications == null) {
+                    logger.warn("Role assignment has no entity classifications. Denying organisation match for org ref {}", orgRef);
+                    return false;
+                }
+                var dataOwnerClassifications = entityClassifications.get(CLASSIFICATION_DATA_OWNER);
+                if (dataOwnerClassifications == null) {
+                    logger.warn("Role assignment is missing {} classification. Denying organisation match for org ref {}", CLASSIFICATION_DATA_OWNER, orgRef);
+                    return false;
+                }
+                return dataOwnerClassifications.stream().anyMatch(c -> c.equals(orgRef));
             }
             logger.debug("Org ref is null for entity: {}", entity);
             return true;

--- a/sobek-app/src/main/java/org/rutebanken/sobek/auth/check/SobekOriganisationChecker.java
+++ b/sobek-app/src/main/java/org/rutebanken/sobek/auth/check/SobekOriganisationChecker.java
@@ -18,11 +18,12 @@ package org.rutebanken.sobek.auth.check;
 
 import org.rutebanken.helper.organisation.OrganisationChecker;
 import org.rutebanken.helper.organisation.RoleAssignment;
-import org.rutebanken.netex.model.Vehicle;
 import org.rutebanken.sobek.model.authorization.OwnedEntity;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
+
+import static org.rutebanken.sobek.auth.AuthorizationConstants.CLASSIFICATION_DATA_OWNER;
 
 @Service
 public class SobekOriganisationChecker implements OrganisationChecker {
@@ -36,7 +37,7 @@ public class SobekOriganisationChecker implements OrganisationChecker {
             if (ownedEntity.getDataOwnerRef() != null) {
                 String orgRef = ownedEntity.getDataOwnerRef().replace(":", "/");
                 logger.debug("Found org ref {} for entity. Returning true if the role assignment contains reference to the organisation", orgRef);
-                return roleAssignment.getEntityClassifications().get("DataOwner").stream().anyMatch(c -> c.equals(orgRef));
+                return roleAssignment.getEntityClassifications().get(CLASSIFICATION_DATA_OWNER).stream().anyMatch(c -> c.equals(orgRef));
             }
             logger.debug("Org ref is null for entity: {}", entity);
             return true;

--- a/sobek-app/src/main/java/org/rutebanken/sobek/config/AuthorizationServiceConfig.java
+++ b/sobek-app/src/main/java/org/rutebanken/sobek/config/AuthorizationServiceConfig.java
@@ -27,6 +27,10 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 @Configuration
 public class AuthorizationServiceConfig {
 
@@ -47,11 +51,8 @@ public class AuthorizationServiceConfig {
                                                                          SobekOriganisationChecker sobekOriganisationChecker,
                                                                          SobekEntityResolver sobekEntityResolver) {
 
-        // // Should be made configurable
-        // Map<String, List<String>> fieldMappings = new HashMap<>();
-        // fieldMappings.put(SUBMODE.toLowerCase(), Arrays.asList("airSubmode", "busSubmode", "coachSubmode", "funicularSubmode", "metroSubmode", "tramSubmode", "telecabinSubmode", "railSubmode", "waterSubmode"));
+        Map<String, List<String>> fieldMappings = new HashMap<>();
 
-
-        return new ReflectionAuthorizationService(roleAssignmentExtractor, authorizationEnabled, sobekOriganisationChecker, null, sobekEntityResolver, null);
+        return new ReflectionAuthorizationService(roleAssignmentExtractor, authorizationEnabled, sobekOriganisationChecker, null, sobekEntityResolver, fieldMappings);
     }
 }

--- a/sobek-app/src/main/java/org/rutebanken/sobek/rest/graphql/GraphQLNames.java
+++ b/sobek-app/src/main/java/org/rutebanken/sobek/rest/graphql/GraphQLNames.java
@@ -41,4 +41,5 @@ public class GraphQLNames {
     public static final String FILTER_ORGANISATION_TYPE = "organisationType";
     public static final String FILTER_IDS = "netexIds";
     public static final String FILTER_NAME = "name";
+    public static final String FILTER_ONLY_USER_AUTHORIZED = "onlyUserAuthorized";
 }

--- a/sobek-app/src/main/java/org/rutebanken/sobek/rest/graphql/GraphQLNames.java
+++ b/sobek-app/src/main/java/org/rutebanken/sobek/rest/graphql/GraphQLNames.java
@@ -108,6 +108,9 @@ public class GraphQLNames {
     public static final String SIZE = "size";
     public static final String SIZE_ARG_DESCRIPTION = "Number of hits per page when using pagination - default is " + DEFAULT_SIZE_VALUE;
 
+    public static final String USER_AUTHORIZED = "onlyUserAuthorized";
+    public static final String USER_AUTHORIZED_ARG_DESCRIPTION = "Only return entities that the user is authorized to use";
+
     public static final String ALL_VERSIONS = "allVersions";
     public static final String ALL_VERSIONS_ARG_DESCRIPTION = "Fetch all versions for entities in result";
 

--- a/sobek-app/src/main/java/org/rutebanken/sobek/rest/graphql/GraphQLNames.java
+++ b/sobek-app/src/main/java/org/rutebanken/sobek/rest/graphql/GraphQLNames.java
@@ -41,5 +41,6 @@ public class GraphQLNames {
     public static final String FILTER_ORGANISATION_TYPE = "organisationType";
     public static final String FILTER_IDS = "netexIds";
     public static final String FILTER_NAME = "name";
+    public static final String FILTER_DATA_OWNER_REF = "dataOwnerRef";
     public static final String FILTER_ONLY_USER_AUTHORIZED = "onlyUserAuthorized";
 }

--- a/sobek-app/src/main/java/org/rutebanken/sobek/rest/graphql/MutationController.java
+++ b/sobek-app/src/main/java/org/rutebanken/sobek/rest/graphql/MutationController.java
@@ -1,5 +1,6 @@
 package org.rutebanken.sobek.rest.graphql;
 
+import org.rutebanken.sobek.auth.AuthorizationService;
 import org.springframework.transaction.annotation.Transactional;
 import jakarta.xml.bind.ValidationException;
 import org.rutebanken.sobek.graphql.converter.DeckPlanNeTExIdConverter;
@@ -16,6 +17,7 @@ import org.springframework.graphql.data.method.annotation.Argument;
 import org.springframework.graphql.data.method.annotation.MutationMapping;
 import org.springframework.graphql.data.method.annotation.SchemaMapping;
 import org.springframework.stereotype.Controller;
+import java.util.List;
 
 @Controller
 @SchemaMapping(typeName = "Mutation")
@@ -28,6 +30,7 @@ public class MutationController {
     private final DeckPlanVersionedSaverService deckPlanVersionedSaverService;
     private final DeckPlanNeTExIdConverter deckPlanIdConverter;
     private final VehicleTypeRepository vehicleTypeRepository;
+    private final AuthorizationService authorizationService;
 
     public MutationController(
             VehicleVersionedSaverService vehicleVersionedSaverService,
@@ -36,7 +39,7 @@ public class MutationController {
             VehicleTypeNeTExIdConverter vehicleTypeIdConverter,
             DeckPlanVersionedSaverService deckPlanVersionedSaverService,
             DeckPlanNeTExIdConverter deckPlanNeTExIdConverter,
-            VehicleTypeRepository vehicleTypeRepository) {
+            VehicleTypeRepository vehicleTypeRepository, AuthorizationService authorizationService) {
         this.vehicleVersionedSaverService = vehicleVersionedSaverService;
         this.vehicleIdConverter = vehicleIdConverter;
         this.vehicleTypeVersionedSaverService = vehicleTypeVersionedSaverService;
@@ -44,12 +47,14 @@ public class MutationController {
         this.deckPlanVersionedSaverService = deckPlanVersionedSaverService;
         this.deckPlanIdConverter = deckPlanNeTExIdConverter;
         this.vehicleTypeRepository = vehicleTypeRepository;
+        this.authorizationService = authorizationService;
     }
 
     @MutationMapping
     public String createOrUpdateVehicle (
             @Argument Vehicle input
     ) throws ValidationException {
+        authorizationService.verifyCanEditEntities(List.of(input));
         input = vehicleIdConverter.convertIncomingId(input);
         if (input.getTransportType() != null) {
             VehicleType vt = vehicleTypeRepository.findFirstByNetexIdOrderByVersionDesc(input.getTransportType().getNetexId());
@@ -66,6 +71,7 @@ public class MutationController {
     public String createOrUpdateVehicleType (
             @Argument VehicleType input
     ) {
+        authorizationService.verifyCanEditEntities(List.of(input));
         input = vehicleTypeIdConverter.convertIncomingId(input);
         var output = vehicleTypeVersionedSaverService.saveNewVersion(input);
         return output.getNetexId();
@@ -75,6 +81,7 @@ public class MutationController {
     public String createOrUpdateDeckPlan (
             @Argument DeckPlan input
     ) {
+        authorizationService.verifyCanEditEntities(List.of(input));
         input = deckPlanIdConverter.convertIncomingId(input);
         var output = deckPlanVersionedSaverService.saveNewVersion(input);
         return output.getNetexId();

--- a/sobek-app/src/main/java/org/rutebanken/sobek/rest/graphql/RegisterGraphQLSchema.java
+++ b/sobek-app/src/main/java/org/rutebanken/sobek/rest/graphql/RegisterGraphQLSchema.java
@@ -15,6 +15,7 @@
 
 package org.rutebanken.sobek.rest.graphql;
 
+import graphql.language.BooleanValue;
 import graphql.language.IntValue;
 import graphql.schema.DataFetcher;
 import graphql.schema.FieldCoordinates;
@@ -30,7 +31,6 @@ import org.rutebanken.sobek.auth.AuthorizationService;
 import org.rutebanken.sobek.model.DataManagedObjectStructure;
 import org.rutebanken.sobek.model.identification.IdentifiedEntity;
 import org.rutebanken.sobek.rest.graphql.fetchers.*;
-import org.rutebanken.sobek.rest.graphql.resolvers.MutableTypeResolver;
 import org.rutebanken.sobek.rest.graphql.scalars.DateScalar;
 import org.rutebanken.sobek.rest.graphql.types.*;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -55,6 +55,7 @@ public class RegisterGraphQLSchema {
 
     public final static int DEFAULT_PAGE_VALUE = 0;
     public final static int DEFAULT_SIZE_VALUE = 20;
+    public final static boolean DEFAULT_USER_AUTHORIZED_VALUE = false;
 
     public GraphQLSchema vehicleRegisterSchema;
 
@@ -125,8 +126,8 @@ public class RegisterGraphQLSchema {
                 .name(INPUT_TYPE_ORGANISATIONS_FILTER)
                 .field(newInputObjectField().name(IDS).type(new GraphQLList(new GraphQLNonNull(GraphQLString))).description("Batch lookup by NeTEx IDs"))
                 .field(newInputObjectField().name(ORGANISATION_TYPE).type(organisationTypeEnumType).description("Filter by organisation type"))
+                .field(newInputObjectField().name(USER_AUTHORIZED).type(GraphQLBoolean).description(USER_AUTHORIZED_ARG_DESCRIPTION).defaultValueLiteral(BooleanValue.of(DEFAULT_USER_AUTHORIZED_VALUE)))
                 .build();
-
 
         GraphQLObjectType deckPlanPageType = createPageType(OUTPUT_TYPE_DECK_PLAN_PAGE, deckPlanObjectType);
         GraphQLObjectType organisationPageType = createPageType(OUTPUT_TYPE_ORGANISATION_PAGE, organisationType);

--- a/sobek-app/src/main/java/org/rutebanken/sobek/rest/graphql/fetchers/DeckPlanFetcher.java
+++ b/sobek-app/src/main/java/org/rutebanken/sobek/rest/graphql/fetchers/DeckPlanFetcher.java
@@ -48,7 +48,8 @@ public class DeckPlanFetcher implements DataFetcher<Map<String, Object>> {
         List<String> netexIds = FilterHelper.getNetexIdsFromFilter(filter);
         String name = FilterHelper.getNameFromFilter(filter);
         List<AllPublicTransportModesEnumeration> modes = FilterHelper.getModesFromFilter(filter);
-        var result = deckPlanRepository.findCurrentFiltered(netexIds, modes, name, PageRequest.of(page, size));
+        String dataOwnerRef = FilterHelper.getDataOwnerRefFromFilter(filter);
+        var result = deckPlanRepository.findCurrentFiltered(dataOwnerRef, netexIds, modes, name, PageRequest.of(page, size));
         return PageResult.from(result, page, size);
     }
 }

--- a/sobek-app/src/main/java/org/rutebanken/sobek/rest/graphql/fetchers/OrganisationFetcher.java
+++ b/sobek-app/src/main/java/org/rutebanken/sobek/rest/graphql/fetchers/OrganisationFetcher.java
@@ -18,6 +18,7 @@ package org.rutebanken.sobek.rest.graphql.fetchers;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 import org.rutebanken.netex.model.OrganisationTypeEnumeration;
+import org.rutebanken.sobek.auth.AuthorizationService;
 import org.rutebanken.sobek.repository.OrganisationRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
@@ -28,8 +29,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.rutebanken.sobek.rest.graphql.GraphQLNames.*;
-import static org.rutebanken.sobek.rest.graphql.RegisterGraphQLSchema.DEFAULT_PAGE_VALUE;
-import static org.rutebanken.sobek.rest.graphql.RegisterGraphQLSchema.DEFAULT_SIZE_VALUE;
+import static org.rutebanken.sobek.rest.graphql.RegisterGraphQLSchema.*;
 
 @Service("organisationFetcher")
 @Transactional
@@ -38,6 +38,9 @@ class OrganisationFetcher implements DataFetcher<Map<String, Object>> {
     @Autowired
     private OrganisationRepository organisationRepository;
 
+    @Autowired
+    private AuthorizationService authorizationService;
+
     @Override
     @SuppressWarnings("unchecked")
     public Map<String, Object> get(DataFetchingEnvironment env) {
@@ -45,19 +48,30 @@ class OrganisationFetcher implements DataFetcher<Map<String, Object>> {
         int size = env.getArgumentOrDefault(SIZE, DEFAULT_SIZE_VALUE);
 
         Map<String, Object> filter = env.getArgument(FILTER);
+
         List<String> ids = null;
         OrganisationTypeEnumeration type = null;
+        Boolean onlyAuthorized = false;
+
         if (filter != null) {
             ids = (List<String>) filter.get(IDS);
             Object orgArg = filter.get(ORGANISATION_TYPE);
+
             if (orgArg instanceof org.rutebanken.netex.model.OrganisationTypeEnumeration t) {
                 type = t;
             } else if (orgArg instanceof String s) {
                 type = OrganisationTypeEnumeration.fromValue(s);
             }
+
+            onlyAuthorized = (Boolean)filter.get(USER_AUTHORIZED);
         }
 
-        var result = organisationRepository.findCurrentFiltered(ids, type, PageRequest.of(page, size));
+        List<String> authorizedIds = null;
+        if(onlyAuthorized != null && onlyAuthorized) {
+            authorizedIds = authorizationService.getOrganisationRefsUserIsAuthorizedFor();
+        }
+
+        var result = organisationRepository.findCurrentFiltered(ids, type, authorizedIds, PageRequest.of(page, size));
         return PageResult.from(result, page, size);
     }
 }

--- a/sobek-app/src/main/java/org/rutebanken/sobek/rest/graphql/fetchers/OrganisationFetcher.java
+++ b/sobek-app/src/main/java/org/rutebanken/sobek/rest/graphql/fetchers/OrganisationFetcher.java
@@ -63,7 +63,7 @@ class OrganisationFetcher implements DataFetcher<Map<String, Object>> {
         }
 
 
-        var result = organisationRepository.findCurrentFiltered(ids, type, PageRequest.of(page, size));
+        var result = organisationRepository.findCurrentFiltered(ids, type, authorizedIds, PageRequest.of(page, size));
         return PageResult.from(result, page, size);
     }
 }

--- a/sobek-app/src/main/java/org/rutebanken/sobek/rest/graphql/fetchers/OrganisationFetcher.java
+++ b/sobek-app/src/main/java/org/rutebanken/sobek/rest/graphql/fetchers/OrganisationFetcher.java
@@ -18,25 +18,27 @@ package org.rutebanken.sobek.rest.graphql.fetchers;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 import org.rutebanken.netex.model.OrganisationTypeEnumeration;
+import org.rutebanken.sobek.auth.AuthorizationService;
 import org.rutebanken.sobek.repository.OrganisationRepository;
+import org.rutebanken.sobek.rest.graphql.helpers.FilterHelper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Map;
 
 import static org.rutebanken.sobek.rest.graphql.GraphQLNames.*;
-import static org.rutebanken.sobek.rest.graphql.RegisterGraphQLSchema.DEFAULT_PAGE_VALUE;
-import static org.rutebanken.sobek.rest.graphql.RegisterGraphQLSchema.DEFAULT_SIZE_VALUE;
 
-@Service("organisationFetcher")
-@Transactional
-class OrganisationFetcher implements DataFetcher<Map<String, Object>> {
+
+@Service
+public class OrganisationFetcher implements DataFetcher<Map<String, Object>> {
 
     @Autowired
     private OrganisationRepository organisationRepository;
+
+    @Autowired
+    private AuthorizationService authorizationService;
 
     @Override
     @SuppressWarnings("unchecked")
@@ -45,25 +47,11 @@ class OrganisationFetcher implements DataFetcher<Map<String, Object>> {
         int size = env.getArgumentOrDefault(SIZE, DEFAULT_SIZE_VALUE);
 
         Map<String, Object> filter = env.getArgument(FILTER);
-        List<String> ids = null;
-        OrganisationTypeEnumeration type = null;
-        if (filter != null) {
-            ids = (List<String>) filter.get(IDS);
-            Object orgArg = filter.get(ORGANISATION_TYPE);
-            if (orgArg instanceof org.rutebanken.netex.model.OrganisationTypeEnumeration t) {
-                type = t;
-            } else if (orgArg instanceof String s) {
-                type = OrganisationTypeEnumeration.fromValue(s);
-            }
-        }
-        onlyAuthorized = (Boolean)filter.get(USER_AUTHORIZED);
-        List<String> authorizedIds = null;
-        if(onlyAuthorized != null && onlyAuthorized) {
-            authorizedIds = authorizationService.getOrganisationRefsUserIsAuthorizedFor();
-        }
-
-
-        var result = organisationRepository.findCurrentFiltered(ids, type, authorizedIds, PageRequest.of(page, size));
+        List<String> netexIds = FilterHelper.getNetexIdsFromFilter(filter);
+        String name = FilterHelper.getNameFromFilter(filter);
+        OrganisationTypeEnumeration type = FilterHelper.getOrganisationTypeFromFilter(filter);
+        List<String> authorizedNetexIds = FilterHelper.getAuthorizedNetexIdsFilter(filter, authorizationService);
+        var result = organisationRepository.findCurrentFiltered(netexIds, type, name, authorizedNetexIds, PageRequest.of(page, size));
         return PageResult.from(result, page, size);
     }
 }

--- a/sobek-app/src/main/java/org/rutebanken/sobek/rest/graphql/fetchers/VehicleFetcher.java
+++ b/sobek-app/src/main/java/org/rutebanken/sobek/rest/graphql/fetchers/VehicleFetcher.java
@@ -48,8 +48,9 @@ public class VehicleFetcher implements DataFetcher<Map<String, Object>> {
         List<String> netexIds = FilterHelper.getNetexIdsFromFilter(filter);
         String name = FilterHelper.getNameFromFilter(filter);
         List<AllPublicTransportModesEnumeration> modes = FilterHelper.getModesFromFilter(filter);
+        String dataOwnerRef = FilterHelper.getDataOwnerRefFromFilter(filter);
 
-        var result = vehicleRepository.findCurrentFiltered(netexIds, modes, name, PageRequest.of(page, size));
+        var result = vehicleRepository.findCurrentFiltered(dataOwnerRef, netexIds, modes, name, PageRequest.of(page, size));
         return PageResult.from(result, page, size);
     }
 }

--- a/sobek-app/src/main/java/org/rutebanken/sobek/rest/graphql/fetchers/VehicleTypeFetcher.java
+++ b/sobek-app/src/main/java/org/rutebanken/sobek/rest/graphql/fetchers/VehicleTypeFetcher.java
@@ -47,8 +47,9 @@ public class VehicleTypeFetcher implements DataFetcher<Map<String, Object>> {
         List<String> netexIds = FilterHelper.getNetexIdsFromFilter(filter);
         String name = FilterHelper.getNameFromFilter(filter);
         List<AllPublicTransportModesEnumeration> modes = FilterHelper.getModesFromFilter(filter);
+        String dataOwnerRef = FilterHelper.getDataOwnerRefFromFilter(filter);
 
-        var result = vehicleTypeRepository.findCurrentFiltered(netexIds, modes, name, PageRequest.of(page, size));
+        var result = vehicleTypeRepository.findCurrentFiltered(dataOwnerRef, netexIds, modes, name, PageRequest.of(page, size));
         return PageResult.from(result, page, size);
     }
 }

--- a/sobek-app/src/main/java/org/rutebanken/sobek/rest/graphql/helpers/FilterHelper.java
+++ b/sobek-app/src/main/java/org/rutebanken/sobek/rest/graphql/helpers/FilterHelper.java
@@ -54,6 +54,11 @@ public class FilterHelper {
         return (String)filter.get(FILTER_NAME);
     }
 
+    public static String getDataOwnerRefFromFilter(Map<String, Object> filter) {
+        if(filter == null) { return null; }
+        return (String)filter.get(FILTER_DATA_OWNER_REF);
+    }
+
     public static OrganisationTypeEnumeration getOrganisationTypeFromFilter(Map<String, Object> filter) {
         if(filter == null) { return null; }
         Object orgArg = filter.get(FILTER_ORGANISATION_TYPE);

--- a/sobek-app/src/main/java/org/rutebanken/sobek/rest/graphql/helpers/FilterHelper.java
+++ b/sobek-app/src/main/java/org/rutebanken/sobek/rest/graphql/helpers/FilterHelper.java
@@ -1,6 +1,7 @@
 package org.rutebanken.sobek.rest.graphql.helpers;
 
 import org.rutebanken.netex.model.OrganisationTypeEnumeration;
+import org.rutebanken.sobek.auth.AuthorizationService;
 import org.rutebanken.sobek.model.vehicle.AllPublicTransportModesEnumeration;
 
 import java.util.List;
@@ -60,6 +61,15 @@ public class FilterHelper {
             return t;
         } else if (orgArg instanceof String s) {
             return OrganisationTypeEnumeration.valueOf(s.toUpperCase());
+        }
+        return null;
+    }
+
+    public static List<String> getAuthorizedNetexIdsFilter(Map<String, Object> filter, AuthorizationService authorizationService) {
+        if(filter == null) { return null; }
+        Boolean onlyAuthorized = (Boolean)filter.get(FILTER_ONLY_USER_AUTHORIZED);
+        if(onlyAuthorized != null && onlyAuthorized) {
+            return authorizationService.getOrganisationRefsUserIsAuthorizedFor();
         }
         return null;
     }

--- a/sobek-app/src/main/java/org/rutebanken/sobek/rest/graphql/helpers/FilterHelper.java
+++ b/sobek-app/src/main/java/org/rutebanken/sobek/rest/graphql/helpers/FilterHelper.java
@@ -55,8 +55,10 @@ public class FilterHelper {
     }
 
     public static String getDataOwnerRefFromFilter(Map<String, Object> filter) {
-        if(filter == null) { return null; }
-        return (String)filter.get(FILTER_DATA_OWNER_REF);
+        if (filter == null || filter.get(FILTER_DATA_OWNER_REF) == null) {
+            throw new IllegalArgumentException("Missing required filter field '" + FILTER_DATA_OWNER_REF + "'");
+        }
+        return (String) filter.get(FILTER_DATA_OWNER_REF);
     }
 
     public static OrganisationTypeEnumeration getOrganisationTypeFromFilter(Map<String, Object> filter) {

--- a/sobek-app/src/main/resources/application-local.properties
+++ b/sobek-app/src/main/resources/application-local.properties
@@ -59,13 +59,14 @@ sobek.oauth2.resourceserver.auth0.entur.partner.jwt.audience=https://api.dev.ent
 sobek.oauth2.resourceserver.auth0.entur.partner.jwt.issuer-uri=https://partner.dev.entur.org/
 
 # For testing startup with baba as role assignment extractor
-#sobek.security.role.assignment.extractor=baba
-#sobek.user.permission.rest.service.url=http://baba.dev.entur.internal/services/organisations/users
-#spring.security.oauth2.client.registration.internal.authorization-grant-type=client_credentials
-#spring.security.oauth2.client.provider.internal.token-uri=https://internal.dev.entur.org/
-#sobek.oauth2.client.audience=https://api.dev.entur.io
-#spring.security.oauth2.client.registration.internal.client-id=id
-#spring.security.oauth2.client.registration.internal.client-secret=secret
+sobek.security.role.assignment.extractor=baba
+sobek.user.permission.rest.service.url=https://api.dev.entur.io/timetable-admin/v1/organisations/users
+spring.security.oauth2.client.registration.internal.authorization-grant-type=client_credentials
+sobek.oauth2.client.audience=https://api.dev.entur.io
+spring.security.oauth2.client.registration.internal.client-id=${SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_INTERNAL_CLIENT_ID}
+spring.security.oauth2.client.registration.internal.client-secret=${SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_INTERNAL_CLIENT_SECRET}
+spring.security.oauth2.client.provider.internal.token-uri=https://internal.dev.entur.org/oauth/token
+
 
 spring.cloud.gcp.pubsub.enabled=false
 
@@ -92,8 +93,8 @@ blobstore.s3.endpoint-override=http://localhost:37566
 spring.cloud.aws.region.static=eu-north-1
 
 security.basic.enabled=false
-management.security.enabled=false
-authorization.enabled=false
+management.security.enabled=true
+authorization.enabled=true
 rutebanken.kubernetes.enabled=false
 
 async.export.path=/tmp

--- a/sobek-app/src/main/resources/db/migration/V8__Add_DataOwnerRef.sql
+++ b/sobek-app/src/main/resources/db/migration/V8__Add_DataOwnerRef.sql
@@ -1,0 +1,11 @@
+ALTER TABLE deck_plan
+    ADD data_owner_ref VARCHAR(255);
+
+ALTER TABLE train
+    ADD data_owner_ref VARCHAR(255);
+
+ALTER TABLE vehicle
+    ADD data_owner_ref VARCHAR(255);
+
+ALTER TABLE vehicle_type
+    ADD data_owner_ref VARCHAR(255);

--- a/sobek-app/src/main/resources/graphql/schema.graphqls
+++ b/sobek-app/src/main/resources/graphql/schema.graphqls
@@ -122,6 +122,7 @@ input OrganisationsFilter {
     netexIds: [String!]
     organisationType: OrganisationType
     name: String
+    onlyUserAuthorized: Boolean
 }
 
 input DeckPlanFilter {

--- a/sobek-app/src/main/resources/graphql/schema.graphqls
+++ b/sobek-app/src/main/resources/graphql/schema.graphqls
@@ -13,6 +13,18 @@ input MultilingualStringInput {
     lang: String
 }
 
+input OrganisationReferenceInput {
+    netexId: String!
+}
+
+input VehicleTypeReferenceInput {
+    netexId: String!
+}
+
+input DeckPlanReferenceInput {
+    netexId: String!
+}
+
 # Enums
 enum FareClass {
     UNKNOWN
@@ -183,6 +195,7 @@ input DeckPlanInput {
     netexId: String
     name: MultilingualStringInput
     description: MultilingualStringInput
+    organisation: OrganisationReferenceInput!
 }
 
 type DeckPlanPage {
@@ -229,10 +242,11 @@ input VehicleInput {
     description: MultilingualStringInput
     registrationNumber: String
     operationalNumber: String
-    transportType: VehicleTypeInput
+    transportType: VehicleTypeReferenceInput
     chassisNumber: String
     buildDate: Date
     registrationDate: Date
+    organisation: OrganisationReferenceInput!
 }
 
 type VehiclePage {
@@ -286,7 +300,7 @@ input VehicleTypeInput {
     passengerCapacity: PassengerCapacityInput
     privateCode: PrivateCodeInput
     keyValues: [KeyValuesInput!]
-    deckPlan: DeckPlanInput
+    deckPlan: DeckPlanReferenceInput
     formDragCoefficient: Float
     rollResistanceCoefficient: Float
     maximumEngineEffectKW: Float
@@ -299,6 +313,7 @@ input VehicleTypeInput {
     lowFloor: Boolean
     selfPropelled: Boolean
     hybridCategory: HybridCategory
+    organisation: OrganisationReferenceInput!
 }
 
 type VehicleTypePage {

--- a/sobek-app/src/main/resources/graphql/schema.graphqls
+++ b/sobek-app/src/main/resources/graphql/schema.graphqls
@@ -13,10 +13,6 @@ input MultilingualStringInput {
     lang: String
 }
 
-input OrganisationReferenceInput {
-    netexId: String!
-}
-
 input VehicleTypeReferenceInput {
     netexId: String!
 }
@@ -110,12 +106,14 @@ input VehicleTypeFilter {
     netexIds: [String!]
     transportModes: [TransportMode!]
     name: String
+    dataOwnerRef: String!
 }
 
 input VehicleFilter {
     netexIds: [String!]
     transportModes: [TransportMode!]
     name: String
+    dataOwnerRef: String!
 }
 
 input OrganisationsFilter {
@@ -129,6 +127,7 @@ input DeckPlanFilter {
     netexIds: [String!]
     transportModes: [TransportMode!]
     name: String
+    dataOwnerRef: String!
 }
 
 # Page types
@@ -196,7 +195,7 @@ input DeckPlanInput {
     netexId: String
     name: MultilingualStringInput
     description: MultilingualStringInput
-    organisation: OrganisationReferenceInput!
+    dataOwnerRef: String!
 }
 
 type DeckPlanPage {
@@ -247,7 +246,7 @@ input VehicleInput {
     chassisNumber: String
     buildDate: Date
     registrationDate: Date
-    organisation: OrganisationReferenceInput!
+    dataOwnerRef: String!
 }
 
 type VehiclePage {
@@ -314,7 +313,7 @@ input VehicleTypeInput {
     lowFloor: Boolean
     selfPropelled: Boolean
     hybridCategory: HybridCategory
-    organisation: OrganisationReferenceInput!
+    dataOwnerRef: String!
 }
 
 type VehicleTypePage {

--- a/sobek-app/src/test/java/org/rutebanken/sobek/rest/graphql/GraphQLMutationsTest.java
+++ b/sobek-app/src/test/java/org/rutebanken/sobek/rest/graphql/GraphQLMutationsTest.java
@@ -106,7 +106,7 @@ class GraphQLMutationsTest {
         // Verify that the dummy vehicle was created and check some of it's data
         given()
                 .contentType(ContentType.JSON)
-                .body(gql("{ vehicles(page: 0, size: 10, filter: { netexIds: [ \"" + resultId + "\" ]  }) { content { netexId, registrationNumber, chassisNumber } totalElements page size } }"))
+                .body(gql("{ vehicles(page: 0, size: 10, filter: { netexIds: [ \"" + resultId + "\" ], dataOwnerRef: \"NOG:Authority:cP4aPiJ7c39\"  }) { content { netexId, registrationNumber, chassisNumber } totalElements page size } }"))
                 .when()
                 .post("/services/vehicles/graphql")
                 .then()
@@ -121,7 +121,7 @@ class GraphQLMutationsTest {
         // Create a dummy vehicle
         given()
                 .contentType(ContentType.JSON)
-                .body(gql(getFixtureContents("/fixtures/GraphQL_VehicleMutation1.QL").replace("AKT:VehicleType:123", "FAKE:VehicleType:123")))
+                .body(gql(getFixtureContents("/fixtures/GraphQL_VehicleMutation1.QL").replace("AKT:VehicleType:124", "FAKE:VehicleType:123")))
                 .when()
                 .post("/services/vehicles/graphql")
                 .then()

--- a/sobek-app/src/test/java/org/rutebanken/sobek/rest/graphql/GraphQLPagedQueriesTest.java
+++ b/sobek-app/src/test/java/org/rutebanken/sobek/rest/graphql/GraphQLPagedQueriesTest.java
@@ -107,6 +107,20 @@ class GraphQLPagedQueriesTest {
     }
 
     @Test
+    void organisations_filterByUserAuthorizedOrganisations() {
+        given()
+                .contentType(ContentType.JSON)
+                .body(gql("{ organisations(page: 0, size: 1000, filter: { onlyUserAuthorized: true }  ) { content { id } totalElements page size } }"))
+                .when()
+                .post("/services/vehicles/graphql")
+                .then()
+                .statusCode(200)
+                .body("data.organisations.content", is(not(empty())))
+                .body("data.organisations.totalElements", greaterThanOrEqualTo(1))
+                .body("data.organisations.page", equalTo(0));
+    }
+
+    @Test
     void vehicleTypes_exposesNewFields() {
         given()
             .contentType(ContentType.JSON)

--- a/sobek-app/src/test/java/org/rutebanken/sobek/rest/graphql/GraphQLPagedQueriesTest.java
+++ b/sobek-app/src/test/java/org/rutebanken/sobek/rest/graphql/GraphQLPagedQueriesTest.java
@@ -66,7 +66,7 @@ class GraphQLPagedQueriesTest {
     void vehicleTypes_returnsPageStructure() {
         given()
             .contentType(ContentType.JSON)
-            .body(gql("{ vehicleTypes(page: 0, size: 10) { content { netexId } totalElements page size } }"))
+            .body(gql("{ vehicleTypes(page: 0, size: 10, filter: { dataOwner: \"NOG:Authority:cP4aPiJ7c39\" } ) { content { netexId } totalElements page size } }"))
         .when()
             .post("/services/vehicles/graphql")
         .then()
@@ -124,7 +124,7 @@ class GraphQLPagedQueriesTest {
     void organisations_filterByUserAuthorizedOrganisations() {
         given()
                 .contentType(ContentType.JSON)
-                .body(gql("{ organisations(page: 0, size: 1000, filter: { onlyUserAuthorized: true }  ) { content { id } totalElements page size } }"))
+                .body(gql("{ organisations(page: 0, size: 1000, filter: { onlyUserAuthorized: true }  ) { content { netexId } totalElements page size } }"))
                 .when()
                 .post("/services/vehicles/graphql")
                 .then()
@@ -138,7 +138,7 @@ class GraphQLPagedQueriesTest {
     void vehicleTypes_exposesNewFields() {
         given()
             .contentType(ContentType.JSON)
-            .body(gql("{ vehicleTypes(page: 0, size: 100, filter: { transportModes: [ BUS ]  } ) { content { netexId, description { value }, name { value }, version, euroClass, passengerCapacity { totalCapacity, standingCapacity, seatingCapacity },  transportMode, created, fuelTypes, propulsionTypes, privateCode { type, value}, formDragCoefficient, maximumRange, length, height, width, weight, vehicles { chassisNumber, netexId, registrationNumber }  } totalElements page size } }"))
+            .body(gql("{ vehicleTypes(page: 0, size: 100, filter: { transportModes: [ BUS ]  dataOwner: \"NOG:Authority:cP4aPiJ7c39\" } ) { content { netexId, description { value }, name { value }, version, euroClass, passengerCapacity { totalCapacity, standingCapacity, seatingCapacity },  transportMode, created, fuelTypes, propulsionTypes, privateCode { type, value}, formDragCoefficient, maximumRange, length, height, width, weight, vehicles { chassisNumber, netexId, registrationNumber }  } totalElements page size } }"))
                 .when()
             .post("/services/vehicles/graphql")
         .then()
@@ -154,7 +154,7 @@ class GraphQLPagedQueriesTest {
     void vehicleTypes_filterByTransportMode() {
         given()
             .contentType(ContentType.JSON)
-            .body(gql("{ vehicleTypes(filter: { transportModes: [ BUS ] }, page: 0, size: 10) { content { netexId transportMode } totalElements } }"))
+            .body(gql("{ vehicleTypes(filter: { transportModes: [ BUS ] dataOwner: \"NOG:Authority:cP4aPiJ7c39\" }, page: 0, size: 10) { content { netexId transportMode } totalElements } }"))
         .when()
             .post("/services/vehicles/graphql")
         .then()
@@ -167,7 +167,7 @@ class GraphQLPagedQueriesTest {
     void vehicleTypes_filterByName() {
         given()
                 .contentType(ContentType.JSON)
-                .body(gql("{ vehicleTypes(filter: { name: \"exqui\" }, page: 0, size: 10) { content { netexId transportMode } totalElements } }"))
+                .body(gql("{ vehicleTypes(filter: { name: \"exqui\" dataOwner: \"NOG:Authority:cP4aPiJ7c39\"  }, page: 0, size: 10) { content { netexId transportMode } totalElements } }"))
                 .when()
                 .post("/services/vehicles/graphql")
                 .then()
@@ -180,7 +180,7 @@ class GraphQLPagedQueriesTest {
     void vehicleTypes_filterByTransportMode_noMatch() {
         given()
             .contentType(ContentType.JSON)
-            .body(gql("{ vehicleTypes(filter: { transportModes: [ TROLLEY_BUS ] }, page: 0, size: 10) { content { netexId } totalElements } }"))
+            .body(gql("{ vehicleTypes(filter: { transportModes: [ TROLLEY_BUS ]  dataOwner: \"NOG:Authority:cP4aPiJ7c39\" }, page: 0, size: 10) { content { netexId } totalElements } }"))
         .when()
             .post("/services/vehicles/graphql")
         .then()
@@ -194,7 +194,7 @@ class GraphQLPagedQueriesTest {
         // First, get the actual NeTEx ID of the imported vehicle type
         String id = given()
             .contentType(ContentType.JSON)
-            .body(gql("{ vehicleTypes(page: 0, size: 1) { content { netexId } } }"))
+            .body(gql("{ vehicleTypes(page: 0, size: 1, filter: {  dataOwner: \"NOG:Authority:cP4aPiJ7c39\" } ) { content { netexId } } }"))
         .when()
             .post("/services/vehicles/graphql")
         .then()
@@ -219,7 +219,7 @@ class GraphQLPagedQueriesTest {
     void vehicleTypes_filterByIds_noMatch() {
         given()
             .contentType(ContentType.JSON)
-            .body(gql("{ vehicleTypes(filter: { netexIds: [\"FAKE:VehicleType:999\"] }, page: 0, size: 10) { content { netexId } totalElements } }"))
+            .body(gql("{ vehicleTypes(filter: { netexIds: [\"FAKE:VehicleType:999\"]  dataOwner: \"NOG:Authority:cP4aPiJ7c39\" }, page: 0, size: 10) { content { netexId } totalElements } }"))
         .when()
             .post("/services/vehicles/graphql")
         .then()
@@ -262,7 +262,7 @@ class GraphQLPagedQueriesTest {
     void deckPlans_getOne() {
         given()
                 .contentType(ContentType.JSON)
-                .body(gql("{ deckPlans(page: 0, size: 10, filter: { netexIds: [ \"NMR:DeckPlan:1\" ]} ) { content { netexId } totalElements page size } }"))
+                .body(gql("{ deckPlans(page: 0, size: 10, filter: { netexIds: [ \"NMR:DeckPlan:1\" ]  dataOwner: \"NOG:Authority:cP4aPiJ7c39\" } ) { content { netexId } totalElements page size } }"))
                 .when()
                 .post("/services/vehicles/graphql")
                 .then()
@@ -278,7 +278,7 @@ class GraphQLPagedQueriesTest {
     void deckPlan_filterByTransportModes() {
         given()
                 .contentType(ContentType.JSON)
-                .body(gql("{ deckPlans (filter: { transportModes: [ BUS ] }, page: 0, size: 10) { content { netexId  } totalElements } }"))
+                .body(gql("{ deckPlans (filter: { transportModes: [ BUS ]  dataOwner: \"NOG:Authority:cP4aPiJ7c39\" }, page: 0, size: 10) { content { netexId  } totalElements } }"))
                 .when()
                 .post("/services/vehicles/graphql")
                 .then()
@@ -291,7 +291,7 @@ class GraphQLPagedQueriesTest {
     void deckPlan_filterByName_VehicleType() {
         given()
                 .contentType(ContentType.JSON)
-                .body(gql("{ deckPlans (filter: { name: \"exqui\" }, page: 0, size: 10) { content { netexId  } totalElements } }"))
+                .body(gql("{ deckPlans (filter: { name: \"exqui\" dataOwnerRef: \"NOG:Authority:cP4aPiJ7c39\" }, page: 0, size: 10) { content { netexId  } totalElements } }"))
                 .when()
                 .post("/services/vehicles/graphql")
                 .then()
@@ -304,7 +304,7 @@ class GraphQLPagedQueriesTest {
     void deckPlan_filterByName_DeckPlan() {
         given()
                 .contentType(ContentType.JSON)
-                .body(gql("{ deckPlans (filter: { name: \"enetasjes leddet\" }, page: 0, size: 10) { content { netexId  } totalElements } }"))
+                .body(gql("{ deckPlans (filter: { name: \"enetasjes leddet\"  dataOwner: \"NOG:Authority:cP4aPiJ7c39\" }, page: 0, size: 10) { content { netexId  } totalElements } }"))
                 .when()
                 .post("/services/vehicles/graphql")
                 .then()
@@ -331,7 +331,7 @@ class GraphQLPagedQueriesTest {
     void vehicles_filterByTransportMode() {
         given()
                 .contentType(ContentType.JSON)
-                .body(gql("{ vehicles(page: 0, size: 100, filter: { transportModes: [ BUS ]  } ) { content { netexId, registrationNumber, operationalNumber, transportType { netexId, length, height, width, transportMode } } totalElements page size } }"))
+                .body(gql("{ vehicles(page: 0, size: 100, filter: { transportModes: [ BUS ]   dataOwner: \"NOG:Authority:cP4aPiJ7c39\" } ) { content { netexId, registrationNumber, operationalNumber, transportType { netexId, length, height, width, transportMode } } totalElements page size } }"))
                 .when()
                 .post("/services/vehicles/graphql")
                 .then()
@@ -344,7 +344,7 @@ class GraphQLPagedQueriesTest {
     void vehicle_filterByName_VehicleType() {
         given()
                 .contentType(ContentType.JSON)
-                .body(gql("{ vehicles(filter: { name: \"exqui\" }, page: 0, size: 10) { content { netexId registrationNumber } totalElements } }"))
+                .body(gql("{ vehicles(filter: { name: \"exqui\"  dataOwner: \"NOG:Authority:cP4aPiJ7c39\" }, page: 0, size: 10) { content { netexId registrationNumber } totalElements } }"))
                 .when()
                 .post("/services/vehicles/graphql")
                 .then()
@@ -357,7 +357,7 @@ class GraphQLPagedQueriesTest {
     void vehicle_filterByName_Vehicle() {
         given()
                 .contentType(ContentType.JSON)
-                .body(gql("{ vehicles(filter: { name: \"bus vehicle\" }, page: 0, size: 10) { content { netexId registrationNumber } totalElements } }"))
+                .body(gql("{ vehicles(filter: { name: \"bus vehicle\"  dataOwner: \"NOG:Authority:cP4aPiJ7c39\" }, page: 0, size: 10) { content { netexId registrationNumber } totalElements } }"))
                 .when()
                 .post("/services/vehicles/graphql")
                 .then()

--- a/sobek-app/src/test/java/org/rutebanken/sobek/rest/graphql/GraphQLPagedQueriesTest.java
+++ b/sobek-app/src/test/java/org/rutebanken/sobek/rest/graphql/GraphQLPagedQueriesTest.java
@@ -26,6 +26,8 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.rutebanken.sobek.SobekTestApplication;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.server.LocalServerPort;
@@ -33,6 +35,8 @@ import org.springframework.boot.test.web.server.LocalServerPort;
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT, classes = SobekTestApplication.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class GraphQLPagedQueriesTest {
+
+    private static final Logger logger = LoggerFactory.getLogger(GraphQLPagedQueriesTest.class);
 
     @LocalServerPort int port;
 
@@ -66,7 +70,7 @@ class GraphQLPagedQueriesTest {
     void vehicleTypes_returnsPageStructure() {
         given()
             .contentType(ContentType.JSON)
-            .body(gql("{ vehicleTypes(page: 0, size: 10, filter: { dataOwner: \"NOG:Authority:cP4aPiJ7c39\" } ) { content { netexId } totalElements page size } }"))
+            .body(gql("{ vehicleTypes(page: 0, size: 10, filter: { dataOwnerRef: \"NOG:Authority:cP4aPiJ7c39\" } ) { content { netexId } totalElements page size } }"))
         .when()
             .post("/services/vehicles/graphql")
         .then()
@@ -138,7 +142,7 @@ class GraphQLPagedQueriesTest {
     void vehicleTypes_exposesNewFields() {
         given()
             .contentType(ContentType.JSON)
-            .body(gql("{ vehicleTypes(page: 0, size: 100, filter: { transportModes: [ BUS ]  dataOwner: \"NOG:Authority:cP4aPiJ7c39\" } ) { content { netexId, description { value }, name { value }, version, euroClass, passengerCapacity { totalCapacity, standingCapacity, seatingCapacity },  transportMode, created, fuelTypes, propulsionTypes, privateCode { type, value}, formDragCoefficient, maximumRange, length, height, width, weight, vehicles { chassisNumber, netexId, registrationNumber }  } totalElements page size } }"))
+            .body(gql("{ vehicleTypes(page: 0, size: 100, filter: { transportModes: [ BUS ]  dataOwnerRef: \"NOG:Authority:cP4aPiJ7c39\" } ) { content { netexId, description { value }, name { value }, version, euroClass, passengerCapacity { totalCapacity, standingCapacity, seatingCapacity },  transportMode, created, fuelTypes, propulsionTypes, privateCode { type, value}, formDragCoefficient, maximumRange, length, height, width, weight, vehicles { chassisNumber, netexId, registrationNumber }  } totalElements page size } }"))
                 .when()
             .post("/services/vehicles/graphql")
         .then()
@@ -154,7 +158,7 @@ class GraphQLPagedQueriesTest {
     void vehicleTypes_filterByTransportMode() {
         given()
             .contentType(ContentType.JSON)
-            .body(gql("{ vehicleTypes(filter: { transportModes: [ BUS ] dataOwner: \"NOG:Authority:cP4aPiJ7c39\" }, page: 0, size: 10) { content { netexId transportMode } totalElements } }"))
+            .body(gql("{ vehicleTypes(filter: { transportModes: [ BUS ] dataOwnerRef: \"NOG:Authority:cP4aPiJ7c39\" }, page: 0, size: 10) { content { netexId transportMode } totalElements } }"))
         .when()
             .post("/services/vehicles/graphql")
         .then()
@@ -167,7 +171,7 @@ class GraphQLPagedQueriesTest {
     void vehicleTypes_filterByName() {
         given()
                 .contentType(ContentType.JSON)
-                .body(gql("{ vehicleTypes(filter: { name: \"exqui\" dataOwner: \"NOG:Authority:cP4aPiJ7c39\"  }, page: 0, size: 10) { content { netexId transportMode } totalElements } }"))
+                .body(gql("{ vehicleTypes(filter: { name: \"exqui\" dataOwnerRef: \"NOG:Authority:cP4aPiJ7c39\"  }, page: 0, size: 10) { content { netexId transportMode } totalElements } }"))
                 .when()
                 .post("/services/vehicles/graphql")
                 .then()
@@ -180,7 +184,7 @@ class GraphQLPagedQueriesTest {
     void vehicleTypes_filterByTransportMode_noMatch() {
         given()
             .contentType(ContentType.JSON)
-            .body(gql("{ vehicleTypes(filter: { transportModes: [ TROLLEY_BUS ]  dataOwner: \"NOG:Authority:cP4aPiJ7c39\" }, page: 0, size: 10) { content { netexId } totalElements } }"))
+            .body(gql("{ vehicleTypes(filter: { transportModes: [ TROLLEY_BUS ]  dataOwnerRef: \"NOG:Authority:cP4aPiJ7c39\" }, page: 0, size: 10) { content { netexId } totalElements } }"))
         .when()
             .post("/services/vehicles/graphql")
         .then()
@@ -194,7 +198,7 @@ class GraphQLPagedQueriesTest {
         // First, get the actual NeTEx ID of the imported vehicle type
         String id = given()
             .contentType(ContentType.JSON)
-            .body(gql("{ vehicleTypes(page: 0, size: 1, filter: {  dataOwner: \"NOG:Authority:cP4aPiJ7c39\" } ) { content { netexId } } }"))
+            .body(gql("{ vehicleTypes(page: 0, size: 1, filter: {  dataOwnerRef: \"NOG:Authority:cP4aPiJ7c39\" } ) { content { netexId } } }"))
         .when()
             .post("/services/vehicles/graphql")
         .then()
@@ -205,7 +209,7 @@ class GraphQLPagedQueriesTest {
         // Filter by that ID — should return exactly one result
         given()
             .contentType(ContentType.JSON)
-            .body(gql("{ vehicleTypes(filter: { netexIds: [\"" + id + "\"] }, page: 0, size: 10) { content { netexId } totalElements } }"))
+            .body(gql("{ vehicleTypes(filter: { netexIds: [\"" + id + "\"],  dataOwnerRef: \"NOG:Authority:cP4aPiJ7c39\"  }, page: 0, size: 10) { content { netexId } totalElements } }"))
         .when()
             .post("/services/vehicles/graphql")
         .then()
@@ -219,7 +223,7 @@ class GraphQLPagedQueriesTest {
     void vehicleTypes_filterByIds_noMatch() {
         given()
             .contentType(ContentType.JSON)
-            .body(gql("{ vehicleTypes(filter: { netexIds: [\"FAKE:VehicleType:999\"]  dataOwner: \"NOG:Authority:cP4aPiJ7c39\" }, page: 0, size: 10) { content { netexId } totalElements } }"))
+            .body(gql("{ vehicleTypes(filter: { netexIds: [\"FAKE:VehicleType:999\"]  dataOwnerRef: \"NOG:Authority:cP4aPiJ7c39\" }, page: 0, size: 10) { content { netexId } totalElements } }"))
         .when()
             .post("/services/vehicles/graphql")
         .then()
@@ -232,7 +236,7 @@ class GraphQLPagedQueriesTest {
     void vehicleTypes_paginationBeyondResults() {
         given()
             .contentType(ContentType.JSON)
-            .body(gql("{ vehicleTypes(page: 999, size: 10) { content { netexId } totalElements page } }"))
+            .body(gql("{ vehicleTypes(page: 999, size: 10, filter: { dataOwnerRef: \"NOG:Authority:cP4aPiJ7c39\" }) { content { netexId } totalElements page } }"))
         .when()
             .post("/services/vehicles/graphql")
         .then()
@@ -248,7 +252,7 @@ class GraphQLPagedQueriesTest {
     void deckPlans_returnsPageStructure() {
         given()
             .contentType(ContentType.JSON)
-            .body(gql("{ deckPlans(page: 0, size: 10) { content { netexId } totalElements page size } }"))
+            .body(gql("{ deckPlans(page: 0, size: 10, filter: { dataOwnerRef: \"NOG:Authority:cP4aPiJ7c39\" }) { content { netexId } totalElements page size } }"))
         .when()
             .post("/services/vehicles/graphql")
         .then()
@@ -262,7 +266,7 @@ class GraphQLPagedQueriesTest {
     void deckPlans_getOne() {
         given()
                 .contentType(ContentType.JSON)
-                .body(gql("{ deckPlans(page: 0, size: 10, filter: { netexIds: [ \"NMR:DeckPlan:1\" ]  dataOwner: \"NOG:Authority:cP4aPiJ7c39\" } ) { content { netexId } totalElements page size } }"))
+                .body(gql("{ deckPlans(page: 0, size: 10, filter: { netexIds: [ \"NMR:DeckPlan:1\" ]  dataOwnerRef: \"NOG:Authority:cP4aPiJ7c39\" } ) { content { netexId } totalElements page size } }"))
                 .when()
                 .post("/services/vehicles/graphql")
                 .then()
@@ -278,7 +282,7 @@ class GraphQLPagedQueriesTest {
     void deckPlan_filterByTransportModes() {
         given()
                 .contentType(ContentType.JSON)
-                .body(gql("{ deckPlans (filter: { transportModes: [ BUS ]  dataOwner: \"NOG:Authority:cP4aPiJ7c39\" }, page: 0, size: 10) { content { netexId  } totalElements } }"))
+                .body(gql("{ deckPlans (filter: { transportModes: [ BUS ]  dataOwnerRef: \"NOG:Authority:cP4aPiJ7c39\" }, page: 0, size: 10) { content { netexId  } totalElements } }"))
                 .when()
                 .post("/services/vehicles/graphql")
                 .then()
@@ -304,7 +308,7 @@ class GraphQLPagedQueriesTest {
     void deckPlan_filterByName_DeckPlan() {
         given()
                 .contentType(ContentType.JSON)
-                .body(gql("{ deckPlans (filter: { name: \"enetasjes leddet\"  dataOwner: \"NOG:Authority:cP4aPiJ7c39\" }, page: 0, size: 10) { content { netexId  } totalElements } }"))
+                .body(gql("{ deckPlans (filter: { name: \"enetasjes leddet\"  dataOwnerRef: \"NOG:Authority:cP4aPiJ7c39\" }, page: 0, size: 10) { content { netexId  } totalElements } }"))
                 .when()
                 .post("/services/vehicles/graphql")
                 .then()
@@ -318,7 +322,7 @@ class GraphQLPagedQueriesTest {
     void deckPlans_defaultPagination() {
         given()
             .contentType(ContentType.JSON)
-            .body(gql("{ deckPlans { content { netexId } totalElements page size } }"))
+            .body(gql("{ deckPlans(filter: { dataOwnerRef: \"NOG:Authority:cP4aPiJ7c39\" } ) { content { netexId } totalElements page size } }"))
         .when()
             .post("/services/vehicles/graphql")
         .then()
@@ -331,7 +335,7 @@ class GraphQLPagedQueriesTest {
     void vehicles_filterByTransportMode() {
         given()
                 .contentType(ContentType.JSON)
-                .body(gql("{ vehicles(page: 0, size: 100, filter: { transportModes: [ BUS ]   dataOwner: \"NOG:Authority:cP4aPiJ7c39\" } ) { content { netexId, registrationNumber, operationalNumber, transportType { netexId, length, height, width, transportMode } } totalElements page size } }"))
+                .body(gql("{ vehicles(page: 0, size: 100, filter: { transportModes: [ BUS ]   dataOwnerRef: \"NOG:Authority:cP4aPiJ7c39\" } ) { content { netexId, registrationNumber, operationalNumber, transportType { netexId, length, height, width, transportMode } } totalElements page size } }"))
                 .when()
                 .post("/services/vehicles/graphql")
                 .then()
@@ -344,7 +348,7 @@ class GraphQLPagedQueriesTest {
     void vehicle_filterByName_VehicleType() {
         given()
                 .contentType(ContentType.JSON)
-                .body(gql("{ vehicles(filter: { name: \"exqui\"  dataOwner: \"NOG:Authority:cP4aPiJ7c39\" }, page: 0, size: 10) { content { netexId registrationNumber } totalElements } }"))
+                .body(gql("{ vehicles(filter: { name: \"exqui\"  dataOwnerRef: \"NOG:Authority:cP4aPiJ7c39\" }, page: 0, size: 10) { content { netexId registrationNumber transportType { netexId } } totalElements } }"))
                 .when()
                 .post("/services/vehicles/graphql")
                 .then()
@@ -357,7 +361,7 @@ class GraphQLPagedQueriesTest {
     void vehicle_filterByName_Vehicle() {
         given()
                 .contentType(ContentType.JSON)
-                .body(gql("{ vehicles(filter: { name: \"bus vehicle\"  dataOwner: \"NOG:Authority:cP4aPiJ7c39\" }, page: 0, size: 10) { content { netexId registrationNumber } totalElements } }"))
+                .body(gql("{ vehicles(filter: { name: \"bus vehicle\"  dataOwnerRef: \"NOG:Authority:cP4aPiJ7c39\" }, page: 0, size: 10) { content { netexId registrationNumber } totalElements } }"))
                 .when()
                 .post("/services/vehicles/graphql")
                 .then()

--- a/sobek-app/src/test/resources/fixtures/GraphQL_VehicleMutation1.QL
+++ b/sobek-app/src/test/resources/fixtures/GraphQL_VehicleMutation1.QL
@@ -9,12 +9,13 @@ mutation {
       lang: "en"
     }
     transportType: {
-        netexId: "AKT:VehicleType:123"
+        netexId: "AKT:VehicleType:124"
     }
     registrationNumber: "AB-12345"
     operationalNumber: "BUS-042"
     chassisNumber: "CHASSIS123456789"
     buildDate: "2024-01-15"
     registrationDate: "2024-02-01"
+    dataOwnerRef: "NOG:Authority:cP4aPiJ7c39"
   })
 }

--- a/sobek-app/src/test/resources/fixtures/vehicle-export-seed.xml
+++ b/sobek-app/src/test/resources/fixtures/vehicle-export-seed.xml
@@ -5,12 +5,23 @@
     <dataObjects>
         <ResourceFrame id="AKT:ResourceFrame:export-seed" version="1">
             <FrameDefaults>
+                <DefaultResponsibilitySetRef ref="TST:ResponsibilitySet:1" />
                 <DefaultLocale>
                     <TimeZone>Europe/Oslo</TimeZone>
                 </DefaultLocale>
             </FrameDefaults>
+            <responsibilitySets>
+                <ResponsibilitySet id="TST:ResponsibilitySet:1" version="1">
+                    <roles>
+                        <ResponsibilityRoleAssignment id="TST:ResponsibilityRoleAssignment:1" version="1">
+                            <DataRoleType>owns</DataRoleType>
+                            <ResponsibleOrganisationRef ref="NOG:Authority:cP4aPiJ7c39"/>
+                        </ResponsibilityRoleAssignment>
+                    </roles>
+                </ResponsibilitySet>
+            </responsibilitySets>
             <vehicleTypes>
-                <VehicleType id="AKT:VehicleType:export-seed" version="1">
+                <VehicleType id="AKT:VehicleType:export-seed" version="1" >
                     <ValidBetween>
                         <FromDate>2026-04-17T00:00:00</FromDate>
                     </ValidBetween>
@@ -19,7 +30,7 @@
                 </VehicleType>
             </vehicleTypes>
             <vehicles>
-                <Vehicle id="AKT:Vehicle:export-seed" version="1">
+                <Vehicle id="AKT:Vehicle:export-seed" version="1" >
                     <ValidBetween>
                         <FromDate>2026-04-17T00:00:00</FromDate>
                     </ValidBetween>

--- a/sobek-app/src/test/resources/fixtures/vehicle-type-import-1.xml
+++ b/sobek-app/src/test/resources/fixtures/vehicle-type-import-1.xml
@@ -5,12 +5,23 @@
     <dataObjects>
         <ResourceFrame version="1" id="TST:ResourceFrame:1">
             <FrameDefaults>
+                <DefaultResponsibilitySetRef ref="TST:ResponsibilitySet:1" />
                 <DefaultLocale>
                     <TimeZone>Europe/Oslo</TimeZone>
                 </DefaultLocale>
             </FrameDefaults>
+            <responsibilitySets>
+                <ResponsibilitySet id="TST:ResponsibilitySet:1" version="1">
+                    <roles>
+                        <ResponsibilityRoleAssignment id="TST:ResponsibilityRoleAssignment:1" version="1">
+                            <DataRoleType>owns</DataRoleType>
+                            <ResponsibleOrganisationRef ref="NOG:Authority:cP4aPiJ7c39"/>
+                        </ResponsibilityRoleAssignment>
+                    </roles>
+                </ResponsibilitySet>
+            </responsibilitySets>
             <vehicleTypes>
-                <VehicleType version="1" id="TST:VehicleType:1">
+                <VehicleType version="1" id="TST:VehicleType:1" >
                     <Name><Text>Exqui City 24</Text></Name>
                     <Description><Text>Van Hool articulated electric bus</Text></Description>
                     <EuroClass>Euro6</EuroClass>
@@ -32,7 +43,7 @@
                     <Height>3.40</Height>
                     <Weight>19500</Weight>
                 </VehicleType>
-                <VehicleType version="1" id="TST:VehicleType:2">
+                <VehicleType version="1" id="TST:VehicleType:2" >
                     <Name><Text>Exqui City 24</Text></Name>
                     <Description><Text>Van Hool articulated electric bus</Text></Description>
                     <EuroClass>Euro6</EuroClass>

--- a/sobek-app/src/test/resources/fixtures/vehicle-type-import-basic.xml
+++ b/sobek-app/src/test/resources/fixtures/vehicle-type-import-basic.xml
@@ -5,10 +5,21 @@
     <dataObjects>
         <ResourceFrame id="RF:1" version="1">
             <FrameDefaults>
+                <DefaultResponsibilitySetRef ref="TST:ResponsibilitySet:1" />
                 <DefaultLocale>
                     <TimeZone>Europe/Oslo</TimeZone>
                 </DefaultLocale>
             </FrameDefaults>
+            <responsibilitySets>
+                <ResponsibilitySet id="TST:ResponsibilitySet:1" version="1">
+                    <roles>
+                        <ResponsibilityRoleAssignment id="TST:ResponsibilityRoleAssignment:1" version="1">
+                            <DataRoleType>owns</DataRoleType>
+                            <ResponsibleOrganisationRef ref="NOG:Authority:cP4aPiJ7c39"/>
+                        </ResponsibilityRoleAssignment>
+                    </roles>
+                </ResponsibilitySet>
+            </responsibilitySets>
             <vehicleTypes>
                 <VehicleType id="AKT:VehicleType:123" version="1">
                     <Name lang="nb"><Text>Exqui City 24</Text></Name>

--- a/sobek-app/src/test/resources/fixtures/vehicle-type-import.xml
+++ b/sobek-app/src/test/resources/fixtures/vehicle-type-import.xml
@@ -5,12 +5,23 @@
     <dataObjects>
         <ResourceFrame version="1" id="TST:ResourceFrame:1">
             <FrameDefaults>
+                <DefaultResponsibilitySetRef ref="TST:ResponsibilitySet:1" />
                 <DefaultLocale>
                     <TimeZone>Europe/Oslo</TimeZone>
                 </DefaultLocale>
             </FrameDefaults>
+            <responsibilitySets>
+                <ResponsibilitySet id="TST:ResponsibilitySet:1" version="1">
+                    <roles>
+                        <ResponsibilityRoleAssignment id="TST:ResponsibilityRoleAssignment:1" version="1">
+                            <DataRoleType>owns</DataRoleType>
+                            <ResponsibleOrganisationRef ref="NOG:Authority:cP4aPiJ7c39"/>
+                        </ResponsibilityRoleAssignment>
+                    </roles>
+                </ResponsibilitySet>
+            </responsibilitySets>
             <vehicleTypes>
-                <VehicleType version="1" id="TST:VehicleType:1">
+                <VehicleType version="1" id="TST:VehicleType:1" >
                     <Name><Text>Exqui City 24</Text></Name>
                     <Description><Text>Van Hool articulated electric bus</Text></Description>
                     <EuroClass>Euro6</EuroClass>

--- a/sobek-model/src/main/java/org/rutebanken/sobek/model/authorization/OwnedEntity.java
+++ b/sobek-model/src/main/java/org/rutebanken/sobek/model/authorization/OwnedEntity.java
@@ -1,0 +1,7 @@
+package org.rutebanken.sobek.model.authorization;
+
+
+public interface OwnedEntity {
+    String getDataOwnerRef();
+    void setDataOwnerRef(String dataOwnerRef);
+}

--- a/sobek-model/src/main/java/org/rutebanken/sobek/model/vehicle/DeckPlan.java
+++ b/sobek-model/src/main/java/org/rutebanken/sobek/model/vehicle/DeckPlan.java
@@ -16,6 +16,7 @@ import org.rutebanken.sobek.model.DataManagedObjectStructure;
 import org.rutebanken.sobek.model.EmbeddableMultilingualString;
 import org.rutebanken.sobek.model.EntityInVersionStructure;
 import org.rutebanken.sobek.model.Value;
+import org.rutebanken.sobek.model.authorization.OwnedEntity;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -23,7 +24,7 @@ import java.util.List;
 @Entity
 @Getter
 @Setter
-public class DeckPlan extends DataManagedObjectStructure {
+public class DeckPlan extends DataManagedObjectStructure implements OwnedEntity {
     @AttributeOverrides({
             @AttributeOverride(name = "value", column = @Column(name = "name_value")),
             @AttributeOverride(name = "lang", column = @Column(name = "name_lang", length = 5))
@@ -44,6 +45,17 @@ public class DeckPlan extends DataManagedObjectStructure {
     @Transient
     private ValidityConditions_RelStructure configurationConditions;
 
+    private String dataOwnerRef;
+
+    @Override
+    public String getDataOwnerRef() {
+        return dataOwnerRef;
+    }
+
+    @Override
+    public void setDataOwnerRef(String dataOwnerRef) {
+        this.dataOwnerRef = dataOwnerRef;
+    }
     // TODO - TBD
 //    private DeckLevels_RelStructure deckLevels;
 

--- a/sobek-model/src/main/java/org/rutebanken/sobek/model/vehicle/TransportType_VersionStructure.java
+++ b/sobek-model/src/main/java/org/rutebanken/sobek/model/vehicle/TransportType_VersionStructure.java
@@ -4,15 +4,15 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
 import org.rutebanken.sobek.model.*;
+import org.rutebanken.sobek.model.authorization.OwnedEntity;
 
 import java.math.BigDecimal;
-import java.util.ArrayList;
 import java.util.List;
 
 @MappedSuperclass
 @Getter
 @Setter
-public class TransportType_VersionStructure extends DataManagedObjectStructure {
+public class TransportType_VersionStructure extends DataManagedObjectStructure implements OwnedEntity {
     @AttributeOverrides({
             @AttributeOverride(name = "value", column = @Column(name = "name_value")),
             @AttributeOverride(name = "lang", column = @Column(name = "name_lang", length = 5))
@@ -51,5 +51,15 @@ public class TransportType_VersionStructure extends DataManagedObjectStructure {
     @ManyToOne
     private org.rutebanken.sobek.model.vehicle.DeckPlan deckPlan;
 
+    private String dataOwnerRef;
 
+    @Override
+    public String getDataOwnerRef() {
+        return dataOwnerRef;
+    }
+
+    @Override
+    public void setDataOwnerRef(String dataOwnerRef) {
+        this.dataOwnerRef = dataOwnerRef;
+    }
 }

--- a/sobek-model/src/main/java/org/rutebanken/sobek/model/vehicle/Vehicle_VersionStructure.java
+++ b/sobek-model/src/main/java/org/rutebanken/sobek/model/vehicle/Vehicle_VersionStructure.java
@@ -6,13 +6,14 @@ import lombok.Getter;
 import lombok.Setter;
 
 import org.rutebanken.sobek.model.*;
+import org.rutebanken.sobek.model.authorization.OwnedEntity;
 
 import java.time.Instant;
 
 @MappedSuperclass
 @Getter
 @Setter
-public class Vehicle_VersionStructure extends DataManagedObjectStructure {
+public class Vehicle_VersionStructure extends DataManagedObjectStructure implements OwnedEntity {
     @AttributeOverrides({
             @AttributeOverride(name = "value", column = @Column(name = "name_value")),
             @AttributeOverride(name = "lang", column = @Column(name = "name_lang", length = 5))
@@ -60,5 +61,17 @@ public class Vehicle_VersionStructure extends DataManagedObjectStructure {
     @Transient
     private Equipments_RelStructure actualVehicleEquipments;
     private Boolean monitored;
+
+    private String dataOwnerRef;
+
+    @Override
+    public String getDataOwnerRef() {
+        return dataOwnerRef;
+    }
+
+    @Override
+    public void setDataOwnerRef(String dataOwnerRef) {
+        this.dataOwnerRef = dataOwnerRef;
+    }
 
 }

--- a/sobek-repository/src/main/java/org/rutebanken/sobek/repository/DeckPlanRepositoryCustom.java
+++ b/sobek-repository/src/main/java/org/rutebanken/sobek/repository/DeckPlanRepositoryCustom.java
@@ -24,9 +24,7 @@ import java.util.List;
 
 public interface DeckPlanRepositoryCustom extends DataManagedObjectStructureRepository<DeckPlan> {
 
-    List<DeckPlan> findAllCurrent();
-
-    Page<DeckPlan> findCurrentFiltered(List<String> netexIds, List<AllPublicTransportModesEnumeration> transportModes, String name, Pageable pageable);
+    Page<DeckPlan> findCurrentFiltered(String dataOwnerRef, List<String> netexIds, List<AllPublicTransportModesEnumeration> transportModes, String name, Pageable pageable);
 
 }
 

--- a/sobek-repository/src/main/java/org/rutebanken/sobek/repository/DeckPlanRepositoryImpl.java
+++ b/sobek-repository/src/main/java/org/rutebanken/sobek/repository/DeckPlanRepositoryImpl.java
@@ -64,12 +64,7 @@ public class DeckPlanRepositoryImpl implements DeckPlanRepositoryCustom {
             "AND (dp.validBetween.toDate IS NULL OR dp.validBetween.toDate >= :now)";
 
     @Override
-    public List<DeckPlan> findAllCurrent() {
-        return findCurrentFiltered(null, null, null, Pageable.unpaged()).getContent();
-    }
-
-    @Override
-    public Page<DeckPlan> findCurrentFiltered(List<String> netexIds, List<AllPublicTransportModesEnumeration> transportModes, String name, Pageable pageable) {
+    public Page<DeckPlan> findCurrentFiltered(String dataOwnerRef, List<String> netexIds, List<AllPublicTransportModesEnumeration> transportModes, String name, Pageable pageable) {
         Instant now = Instant.now();
 
         StringBuilder filterSuffix = new StringBuilder();
@@ -83,32 +78,33 @@ public class DeckPlanRepositoryImpl implements DeckPlanRepositoryCustom {
             name = "%" + QueryHelper.escapeForLike(name.toLowerCase()) + "%";
             filterSuffix.append(" AND (dp.name is not null and lower(dp.name.value) LIKE :name ESCAPE '\\' or exists(from VehicleType vt where vt.deckPlan = dp and vt.name is not null and lower(vt.name.value) LIKE :name ESCAPE '\\'))");
         }
+        filterSuffix.append(" AND dp.dataOwnerRef = :dataOwnerRef");
 
 
         String baseJpql = "SELECT DISTINCT dp FROM DeckPlan dp " + CURRENT_BASE_WHERE + filterSuffix;
 
         if (pageable.isUnpaged()) {
             TypedQuery<DeckPlan> query = entityManager.createQuery(baseJpql, DeckPlan.class);
-            setFilterParams(query, netexIds, transportModes, name, now);
+            setFilterParams(query, dataOwnerRef, netexIds, transportModes, name, now);
             List<DeckPlan> results = query.getResultList();
             return new PageImpl<>(results);
         }
 
         String countJpql = "SELECT COUNT(DISTINCT dp) FROM DeckPlan dp " + CURRENT_BASE_WHERE + filterSuffix;
         TypedQuery<Long> countQuery = entityManager.createQuery(countJpql, Long.class);
-        setFilterParams(countQuery, netexIds, transportModes, name, now);
+        setFilterParams(countQuery, dataOwnerRef, netexIds, transportModes, name, now);
 
         long total = countQuery.getSingleResult();
 
         TypedQuery<DeckPlan> query = entityManager.createQuery(baseJpql + " ORDER BY dp.id", DeckPlan.class);
-        setFilterParams(query, netexIds, transportModes, name, now);
+        setFilterParams(query, dataOwnerRef, netexIds, transportModes, name, now);
         query.setFirstResult((int) pageable.getOffset());
         query.setMaxResults(pageable.getPageSize());
 
         return new PageImpl<>(query.getResultList(), pageable, total);
     }
 
-    private void setFilterParams(Query query, List<String> netexIds, List<AllPublicTransportModesEnumeration> transportModes, String name, Instant now) {
+    private void setFilterParams(Query query, String dataOwnerRef, List<String> netexIds, List<AllPublicTransportModesEnumeration> transportModes, String name, Instant now) {
         query.setParameter("now", now);
         if (netexIds != null && !netexIds.isEmpty()) {
             query.setParameter("netexIds", netexIds);
@@ -119,6 +115,7 @@ public class DeckPlanRepositoryImpl implements DeckPlanRepositoryCustom {
         if(name != null && !name.isEmpty()) {
             query.setParameter("name", name);
         }
+        query.setParameter("dataOwnerRef", dataOwnerRef);
     }
 
 }

--- a/sobek-repository/src/main/java/org/rutebanken/sobek/repository/OrganisationRepository.java
+++ b/sobek-repository/src/main/java/org/rutebanken/sobek/repository/OrganisationRepository.java
@@ -8,6 +8,6 @@ import org.springframework.data.domain.Pageable;
 import java.util.List;
 
 public interface OrganisationRepository {
-    Page<Organisation> findCurrentFiltered(List<String> ids, OrganisationTypeEnumeration organisationType, Pageable pageable);
+    Page<Organisation> findCurrentFiltered(List<String> ids, OrganisationTypeEnumeration organisationType, List<String> authorizedIds, Pageable pageable);
 }
 

--- a/sobek-repository/src/main/java/org/rutebanken/sobek/repository/OrganisationRepository.java
+++ b/sobek-repository/src/main/java/org/rutebanken/sobek/repository/OrganisationRepository.java
@@ -8,6 +8,6 @@ import org.springframework.data.domain.Pageable;
 import java.util.List;
 
 public interface OrganisationRepository {
-    Page<Organisation> findCurrentFiltered(List<String> ids, OrganisationTypeEnumeration organisationType, List<String> authorizedIds, Pageable pageable);
+    Page<Organisation> findCurrentFiltered(List<String> ids, OrganisationTypeEnumeration organisationType, String name, List<String> authorizedIds, Pageable pageable);
 }
 

--- a/sobek-repository/src/main/java/org/rutebanken/sobek/repository/OrganisationRepositoryImpl.java
+++ b/sobek-repository/src/main/java/org/rutebanken/sobek/repository/OrganisationRepositoryImpl.java
@@ -28,7 +28,7 @@ public class OrganisationRepositoryImpl implements OrganisationRepository {
     }
 
     @Override
-    public Page<Organisation> findCurrentFiltered(List<String> ids, OrganisationTypeEnumeration organisationType, Pageable pageable) {
+    public Page<Organisation> findCurrentFiltered(List<String> ids, OrganisationTypeEnumeration organisationType, List<String> authorizedIds, Pageable pageable) {
         List<? extends Organisation_VersionStructure> organisations;
 
         if(organisationType == null) {
@@ -43,6 +43,14 @@ public class OrganisationRepositoryImpl implements OrganisationRepository {
 
         if(ids != null && !ids.isEmpty()) {
             Set<String> idSet = new HashSet<>(ids);
+            organisations = organisations
+                    .stream()
+                    .filter(org -> idSet.contains(org.getId()))
+                    .toList();
+        }
+
+        if(authorizedIds != null) {
+            Set<String> idSet = new HashSet<>(authorizedIds);
             organisations = organisations
                     .stream()
                     .filter(org -> idSet.contains(org.getId()))
@@ -67,14 +75,13 @@ public class OrganisationRepositoryImpl implements OrganisationRepository {
 
     private List<Organisation> mapOrganisations(List<? extends Organisation_VersionStructure> organisations) {
         // Convert to Organisation records
-        List<Organisation> organisationList = organisations.stream()
+        return organisations.stream()
                 .map(org -> new Organisation(
                         org.getId(),
                         multilingualStringMapper.mapToSobek(org.getName()),
                         getOrganisationType(org)
                 ))
                 .toList();
-        return organisationList;
     }
 
     private OrganisationTypeEnumeration getOrganisationType(Organisation_VersionStructure org) {

--- a/sobek-repository/src/main/java/org/rutebanken/sobek/repository/OrganisationRepositoryImpl.java
+++ b/sobek-repository/src/main/java/org/rutebanken/sobek/repository/OrganisationRepositoryImpl.java
@@ -28,7 +28,7 @@ public class OrganisationRepositoryImpl implements OrganisationRepository {
     }
 
     @Override
-    public Page<Organisation> findCurrentFiltered(List<String> ids, OrganisationTypeEnumeration organisationType, List<String> authorizedIds, Pageable pageable) {
+    public Page<Organisation> findCurrentFiltered(List<String> ids, OrganisationTypeEnumeration organisationType, String name, List<String> authorizedIds, Pageable pageable) {
         List<? extends Organisation_VersionStructure> organisations;
 
         if(organisationType == null) {

--- a/sobek-repository/src/main/java/org/rutebanken/sobek/repository/OrganisationRepositoryImpl.java
+++ b/sobek-repository/src/main/java/org/rutebanken/sobek/repository/OrganisationRepositoryImpl.java
@@ -77,8 +77,8 @@ public class OrganisationRepositoryImpl implements OrganisationRepository {
         int start = (int) pageable.getOffset();
         int end = Math.min(start + pageable.getPageSize(), mappedOrganisations.size());
         
-        if (start >= organisations.size()) {
-            return new PageImpl<>(List.of(), pageable, organisations.size());
+        if (start >= mappedOrganisations.size()) {
+            return new PageImpl<>(List.of(), pageable, mappedOrganisations.size());
         }
 
         List<Organisation> pagedList = mappedOrganisations.subList(start, end);

--- a/sobek-repository/src/main/java/org/rutebanken/sobek/repository/OrganisationRepositoryImpl.java
+++ b/sobek-repository/src/main/java/org/rutebanken/sobek/repository/OrganisationRepositoryImpl.java
@@ -28,7 +28,7 @@ public class OrganisationRepositoryImpl implements OrganisationRepository {
     }
 
     @Override
-    public Page<Organisation> findCurrentFiltered(List<String> ids, OrganisationTypeEnumeration organisationType, String name, List<String> authorizedIds, Pageable pageable) {
+    public Page<Organisation> findCurrentFiltered(List<String> netexIds, OrganisationTypeEnumeration organisationType, String name, List<String> authorizedIds, Pageable pageable) {
         List<? extends Organisation_VersionStructure> organisations;
 
         if(organisationType == null) {
@@ -41,8 +41,8 @@ public class OrganisationRepositoryImpl implements OrganisationRepository {
             throw new IllegalArgumentException("Unsupported organisation type filter: " + organisationType);
         }
 
-        if(ids != null && !ids.isEmpty()) {
-            Set<String> idSet = new HashSet<>(ids);
+        if(netexIds != null && !netexIds.isEmpty()) {
+            Set<String> idSet = new HashSet<>(netexIds);
             organisations = organisations
                     .stream()
                     .filter(org -> idSet.contains(org.getId()))
@@ -57,20 +57,32 @@ public class OrganisationRepositoryImpl implements OrganisationRepository {
                     .toList();
         }
 
+        var mappedOrganisations = mapOrganisations(organisations);
+
+        if(name != null && !name.isEmpty()) {
+            var lowerName = name.toLowerCase();
+            mappedOrganisations = mappedOrganisations
+                    .stream()
+                    .filter(org -> org.name() != null
+                            && org.name().getValue() != null
+                            && org.name().getValue().toLowerCase().contains(lowerName))
+                    .toList();
+        }
+
         // Handle pagination
         if (pageable.isUnpaged()) {
-            return new PageImpl<>(mapOrganisations(organisations));
+            return new PageImpl<>(mappedOrganisations);
         }
 
         int start = (int) pageable.getOffset();
-        int end = Math.min(start + pageable.getPageSize(), organisations.size());
+        int end = Math.min(start + pageable.getPageSize(), mappedOrganisations.size());
         
         if (start >= organisations.size()) {
             return new PageImpl<>(List.of(), pageable, organisations.size());
         }
 
-        List<Organisation> pagedList = mapOrganisations(organisations.subList(start, end));
-        return new PageImpl<>(pagedList, pageable, organisations.size());
+        List<Organisation> pagedList = mappedOrganisations.subList(start, end);
+        return new PageImpl<>(pagedList, pageable, mappedOrganisations.size());
     }
 
     private List<Organisation> mapOrganisations(List<? extends Organisation_VersionStructure> organisations) {

--- a/sobek-repository/src/main/java/org/rutebanken/sobek/repository/VehicleRepositoryCustom.java
+++ b/sobek-repository/src/main/java/org/rutebanken/sobek/repository/VehicleRepositoryCustom.java
@@ -28,7 +28,7 @@ public interface VehicleRepositoryCustom extends DataManagedObjectStructureRepos
 
     void healthCheck();
 
-    Page<Vehicle> findCurrentFiltered(List<String> netexIds, List<AllPublicTransportModesEnumeration> transportModes, String name, Pageable pageable);
+    Page<Vehicle> findCurrentFiltered(String dataOwnerRef, List<String> netexIds, List<AllPublicTransportModesEnumeration> transportModes, String name, Pageable pageable);
 
 
 }

--- a/sobek-repository/src/main/java/org/rutebanken/sobek/repository/VehicleRepositoryImpl.java
+++ b/sobek-repository/src/main/java/org/rutebanken/sobek/repository/VehicleRepositoryImpl.java
@@ -80,7 +80,7 @@ public class VehicleRepositoryImpl implements VehicleRepositoryCustom {
 
 
     @Override
-    public Page<Vehicle> findCurrentFiltered(List<String> netexIds, List<AllPublicTransportModesEnumeration> transportModes, String name, Pageable pageable) {
+    public Page<Vehicle> findCurrentFiltered(String dataOwnerRef, List<String> netexIds, List<AllPublicTransportModesEnumeration> transportModes, String name, Pageable pageable) {
         Instant now = Instant.now();
 
         // Build dynamic WHERE suffix for optional filters
@@ -95,6 +95,7 @@ public class VehicleRepositoryImpl implements VehicleRepositoryCustom {
             name = "%" + QueryHelper.escapeForLike(name.toLowerCase()) + "%";
             filterSuffix.append(" AND ((v.name is not null and lower(v.name.value) LIKE :name ESCAPE '\\') or (v.transportType is not null and v.transportType.name is not null and lower(v.transportType.name.value) LIKE :name ESCAPE '\\'))");
         }
+        filterSuffix.append(" AND v.dataOwnerRef = :dataOwnerRef and (v.transportType is null or v.transportType.dataOwnerRef = :dataOwnerRef)");
 
         String fetchJpql = "SELECT DISTINCT v FROM Vehicle v " +
                 "LEFT JOIN FETCH v.transportType vt WHERE " +
@@ -107,7 +108,7 @@ public class VehicleRepositoryImpl implements VehicleRepositoryCustom {
         if (pageable.isUnpaged()) {
             TypedQuery<Vehicle> fetchQuery = entityManager.createQuery(fetchJpql, Vehicle.class);
             fetchQuery.setParameter("now", now);
-            setFilterParams(fetchQuery, netexIds, transportModes, name);
+            setFilterParams(fetchQuery, dataOwnerRef, netexIds, transportModes, name);
             return new PageImpl<>(fetchQuery.getResultList());
         }
 
@@ -121,20 +122,20 @@ public class VehicleRepositoryImpl implements VehicleRepositoryCustom {
 
         TypedQuery<Long> countQuery = entityManager.createQuery(countJpql, Long.class);
         countQuery.setParameter("now", now);
-        setFilterParams(countQuery, netexIds, transportModes, name);
+        setFilterParams(countQuery, dataOwnerRef, netexIds, transportModes, name);
         long total = countQuery.getSingleResult();
 
         // Fetch — in-memory pagination (HHH90003004) is acceptable for this small dataset
         TypedQuery<Vehicle> fetchQuery = entityManager.createQuery(fetchJpql, Vehicle.class);
         fetchQuery.setParameter("now", now);
-        setFilterParams(fetchQuery, netexIds, transportModes, name);
+        setFilterParams(fetchQuery, dataOwnerRef, netexIds, transportModes, name);
         fetchQuery.setFirstResult((int) pageable.getOffset());
         fetchQuery.setMaxResults(pageable.getPageSize());
 
         return new PageImpl<>(fetchQuery.getResultList(), pageable, total);
     }
 
-    private void setFilterParams(Query query, List<String> netexIds, List<AllPublicTransportModesEnumeration> transportModes, String name) {
+    private void setFilterParams(Query query, String dataOwnerRef, List<String> netexIds, List<AllPublicTransportModesEnumeration> transportModes, String name) {
         if (netexIds != null && !netexIds.isEmpty()) {
             query.setParameter("netexIds", netexIds);
         }
@@ -144,6 +145,7 @@ public class VehicleRepositoryImpl implements VehicleRepositoryCustom {
         if(name != null && !name.isEmpty()) {
             query.setParameter("name", name);
         }
+        query.setParameter("dataOwnerRef", dataOwnerRef);
     }
 
 

--- a/sobek-repository/src/main/java/org/rutebanken/sobek/repository/VehicleTypeRepositoryCustom.java
+++ b/sobek-repository/src/main/java/org/rutebanken/sobek/repository/VehicleTypeRepositoryCustom.java
@@ -24,9 +24,7 @@ import java.util.List;
 
 public interface VehicleTypeRepositoryCustom extends DataManagedObjectStructureRepository<VehicleType> {
 
-    List<VehicleType> findAllCurrent();
-
-    Page<VehicleType> findCurrentFiltered(List<String> netexIds, List<AllPublicTransportModesEnumeration> transportModes, String name, Pageable pageable);
+    Page<VehicleType> findCurrentFiltered(String dataOwnerRef, List<String> netexIds, List<AllPublicTransportModesEnumeration> transportModes, String name, Pageable pageable);
 
     void moveToDeckPlan(Long fromDeckPlanId, Long toDeckPlanId);
 }

--- a/sobek-repository/src/main/java/org/rutebanken/sobek/repository/VehicleTypeRepositoryImpl.java
+++ b/sobek-repository/src/main/java/org/rutebanken/sobek/repository/VehicleTypeRepositoryImpl.java
@@ -70,12 +70,7 @@ public class VehicleTypeRepositoryImpl implements VehicleTypeRepositoryCustom {
             "AND (v.validBetween.toDate IS NULL OR v.validBetween.toDate >= :now)))";
 
     @Override
-    public List<VehicleType> findAllCurrent() {
-        return findCurrentFiltered(null, null, null, Pageable.unpaged()).getContent();
-    }
-
-    @Override
-    public Page<VehicleType> findCurrentFiltered(List<String> netexIds, List<AllPublicTransportModesEnumeration> transportModes, String name, Pageable pageable) {
+    public Page<VehicleType> findCurrentFiltered(String dataOwnerRef, List<String> netexIds, List<AllPublicTransportModesEnumeration> transportModes, String name, Pageable pageable) {
         Instant now = Instant.now();
 
         // Build dynamic WHERE suffix for optional filters
@@ -90,6 +85,7 @@ public class VehicleTypeRepositoryImpl implements VehicleTypeRepositoryCustom {
             name = "%" + QueryHelper.escapeForLike(name.toLowerCase()) + "%";
             filterSuffix.append(" AND vt.name is not null and lower(vt.name.value) LIKE :name");
         }
+        filterSuffix.append(" AND vt.dataOwnerRef = :dataOwnerRef");
 
         String fetchJpql = "SELECT DISTINCT vt FROM VehicleType vt " +
                 "LEFT JOIN FETCH vt.vehicles v " +
@@ -99,7 +95,7 @@ public class VehicleTypeRepositoryImpl implements VehicleTypeRepositoryCustom {
 
         if (pageable.isUnpaged()) {
             TypedQuery<VehicleType> fetchQuery = entityManager.createQuery(fetchJpql, VehicleType.class);
-            setFilterParams(fetchQuery, netexIds, transportModes, name, now);
+            setFilterParams(fetchQuery, dataOwnerRef, netexIds, transportModes, name, now);
             return new PageImpl<>(fetchQuery.getResultList());
         }
 
@@ -107,19 +103,19 @@ public class VehicleTypeRepositoryImpl implements VehicleTypeRepositoryCustom {
         String countJpql = "SELECT COUNT(vt) FROM VehicleType vt " +
                 VT_CURRENT_WHERE + filterSuffix;
         TypedQuery<Long> countQuery = entityManager.createQuery(countJpql, Long.class);
-        setFilterParams(countQuery, netexIds, transportModes, name, now);
+        setFilterParams(countQuery, dataOwnerRef, netexIds, transportModes, name, now);
         long total = countQuery.getSingleResult();
 
         // Fetch — in-memory pagination (HHH90003004) is acceptable for this small dataset
         TypedQuery<VehicleType> fetchQuery = entityManager.createQuery(fetchJpql, VehicleType.class);
-        setFilterParams(fetchQuery, netexIds, transportModes, name, now);
+        setFilterParams(fetchQuery, dataOwnerRef, netexIds, transportModes, name, now);
         fetchQuery.setFirstResult((int) pageable.getOffset());
         fetchQuery.setMaxResults(pageable.getPageSize());
 
         return new PageImpl<>(fetchQuery.getResultList(), pageable, total);
     }
 
-    private void setFilterParams(Query query, List<String> netexIds, List<AllPublicTransportModesEnumeration> transportModes, String name, Instant now) {
+    private void setFilterParams(Query query, String dataOwnerRef, List<String> netexIds, List<AllPublicTransportModesEnumeration> transportModes, String name, Instant now) {
         query.setParameter("now", now);
         if (netexIds != null && !netexIds.isEmpty()) {
             query.setParameter("netexIds", netexIds);
@@ -130,6 +126,7 @@ public class VehicleTypeRepositoryImpl implements VehicleTypeRepositoryCustom {
         if(name != null && !name.isEmpty()) {
             query.setParameter("name", name);
         }
+        query.setParameter("dataOwnerRef", dataOwnerRef);
     }
 
     @Override

--- a/sobek-service/src/main/java/org/rutebanken/sobek/auth/AuthorizationConstants.java
+++ b/sobek-service/src/main/java/org/rutebanken/sobek/auth/AuthorizationConstants.java
@@ -1,0 +1,9 @@
+package org.rutebanken.sobek.auth;
+
+public final class AuthorizationConstants {
+    public static final String ROLE_DELETE_VEHICLE_DATA = "deleteVehicleType";
+    public static final String ROLE_EDIT_VEHICLE_DATA = "editVehicleType";
+
+    private AuthorizationConstants() {
+    }
+}

--- a/sobek-service/src/main/java/org/rutebanken/sobek/auth/AuthorizationConstants.java
+++ b/sobek-service/src/main/java/org/rutebanken/sobek/auth/AuthorizationConstants.java
@@ -3,6 +3,7 @@ package org.rutebanken.sobek.auth;
 public final class AuthorizationConstants {
     public static final String ROLE_DELETE_VEHICLE_DATA = "deleteVehicleType";
     public static final String ROLE_EDIT_VEHICLE_DATA = "editVehicleType";
+    public static final String CLASSIFICATION_DATA_OWNER = "DataOwner";
 
     private AuthorizationConstants() {
     }

--- a/sobek-service/src/main/java/org/rutebanken/sobek/auth/AuthorizationService.java
+++ b/sobek-service/src/main/java/org/rutebanken/sobek/auth/AuthorizationService.java
@@ -4,6 +4,7 @@ import org.rutebanken.sobek.model.EntityStructure;
 import org.springframework.security.access.AccessDeniedException;
 
 import java.util.Collection;
+import java.util.List;
 
 /**
  * Authorization service interface for managing authorization of users to perform operations
@@ -64,4 +65,10 @@ public interface AuthorizationService {
       * @return {@code true} if the user is a guest, otherwise {@code false}.
       */
     boolean isGuest();
+
+    /**
+     * Get the organisation refs the user is authorized for. If authorization is disabled, return null, which means "all organisations".
+     * @return A list of organisation refs, e.g. "NOG:Authority:23A2N7V6Blr"
+     */
+    List<String> getOrganisationRefsUserIsAuthorizedFor();
 }

--- a/sobek-service/src/main/java/org/rutebanken/sobek/auth/DefaultAuthorizationService.java
+++ b/sobek-service/src/main/java/org/rutebanken/sobek/auth/DefaultAuthorizationService.java
@@ -108,7 +108,8 @@ public class DefaultAuthorizationService implements AuthorizationService {
 
         Set<String> organisationRefs = new HashSet<>();
         roleAssignments.forEach(roleAssignment -> {
-            if(roleAssignment.getRole().equals(ROLE_EDIT_VEHICLE_DATA)) {  // Maybe return also "read" or "delete"? Review this later on, for now only "edit" is needed.
+            if(roleAssignment.getRole().equals(ROLE_EDIT_VEHICLE_DATA)
+                    && roleAssignment.getEntityClassifications() != null) {  // Maybe return also "read" or "delete"? Review this later on, for now only "edit" is needed.
                 List<String> dataOwnersAllowed = roleAssignment.getEntityClassifications().get(CLASSIFICATION_DATA_OWNER);
                 if(dataOwnersAllowed != null) {
                     organisationRefs.addAll(dataOwnersAllowed.stream().map(dataOwner -> dataOwner.replace("/", ":")).toList());

--- a/sobek-service/src/main/java/org/rutebanken/sobek/auth/DefaultAuthorizationService.java
+++ b/sobek-service/src/main/java/org/rutebanken/sobek/auth/DefaultAuthorizationService.java
@@ -102,6 +102,8 @@ public class DefaultAuthorizationService implements AuthorizationService {
 
     @Override
     public List<String> getOrganisationRefsUserIsAuthorizedFor() {
+        if(!authorizationEnabled) { return null; }
+
         List<RoleAssignment> roleAssignments = roleAssignmentExtractor.getRoleAssignmentsForUser();
 
         Set<String> organisationRefs = new HashSet<>();

--- a/sobek-service/src/main/java/org/rutebanken/sobek/auth/DefaultAuthorizationService.java
+++ b/sobek-service/src/main/java/org/rutebanken/sobek/auth/DefaultAuthorizationService.java
@@ -14,8 +14,8 @@ import java.util.Collection;
 import java.util.List;
 
 import static org.rutebanken.helper.organisation.AuthorizationConstants.ENTITY_CLASSIFIER_ALL_ATTRIBUTES;
-import static org.rutebanken.helper.organisation.AuthorizationConstants.ROLE_DELETE_STOPS;
-import static org.rutebanken.helper.organisation.AuthorizationConstants.ROLE_EDIT_STOPS;
+import static org.rutebanken.sobek.auth.AuthorizationConstants.ROLE_DELETE_VEHICLE_DATA;
+import static org.rutebanken.sobek.auth.AuthorizationConstants.ROLE_EDIT_VEHICLE_DATA;
 
 public class DefaultAuthorizationService implements AuthorizationService {
     private final DataScopedAuthorizationService dataScopedAuthorizationService;
@@ -35,15 +35,13 @@ public class DefaultAuthorizationService implements AuthorizationService {
         if(hasNoAuthentications()) {
             return false;
         }
-        // For now, if the user is authenticated, we assume they can edit all entities.
-        return true;
-        // return verifyCanEditAllEntities(roleAssignmentExtractor.getRoleAssignmentsForUser());
+        return verifyCanEditAllEntities(roleAssignmentExtractor.getRoleAssignmentsForUser());
     }
 
     boolean verifyCanEditAllEntities(List<RoleAssignment> roleAssignments) {
         return roleAssignments
                 .stream()
-                .anyMatch(roleAssignment -> ROLE_EDIT_STOPS.equals(roleAssignment.getRole())
+                .anyMatch(roleAssignment -> ROLE_EDIT_VEHICLE_DATA.equals(roleAssignment.getRole())
                                              && roleAssignment.getEntityClassifications() != null
                                              && roleAssignment.getEntityClassifications().get(AuthorizationConstants.ENTITY_TYPE) != null
                                              && roleAssignment.getEntityClassifications().get(AuthorizationConstants.ENTITY_TYPE).contains(ENTITY_CLASSIFIER_ALL_ATTRIBUTES)
@@ -53,35 +51,28 @@ public class DefaultAuthorizationService implements AuthorizationService {
 
     @Override
     public boolean canEditEntities(Collection<? extends EntityStructure> entities) {
-        // For now, if the user is authenticated, we assume they can edit all entities.
-        return true;
-        //return dataScopedAuthorizationService.isAuthorized(ROLE_EDIT_STOPS, entities);
+        return dataScopedAuthorizationService.isAuthorized(ROLE_EDIT_VEHICLE_DATA, entities);
     }
 
 
     @Override
     public void verifyCanEditEntities(Collection<? extends EntityStructure> entities) {
-        // For now, if the user is authenticated, we assume they can edit all entities.
-        return;
-//        dataScopedAuthorizationService.assertAuthorized(ROLE_EDIT_STOPS, entities);
+        dataScopedAuthorizationService.assertAuthorized(ROLE_EDIT_VEHICLE_DATA, entities);
     }
 
     @Override
     public void verifyCanDeleteEntities(Collection<? extends EntityStructure> entities) {
-        // For now, if the user is authenticated, we assume they can edit all entities.
-        return;
-//        dataScopedAuthorizationService.assertAuthorized(ROLE_DELETE_STOPS, entities);
-
+        dataScopedAuthorizationService.assertAuthorized(ROLE_DELETE_VEHICLE_DATA, entities);
     }
 
     @Override
     public boolean canDeleteEntity(EntityStructure entity) {
-        return canEditDeleteEntity(entity, ROLE_DELETE_STOPS);
+        return canEditDeleteEntity(entity, ROLE_DELETE_VEHICLE_DATA);
     }
 
     @Override
     public boolean canEditEntity(EntityStructure entity) {
-        return canEditDeleteEntity(entity, ROLE_EDIT_STOPS);
+        return canEditDeleteEntity(entity, ROLE_EDIT_VEHICLE_DATA);
     }
 
     @Override

--- a/sobek-service/src/main/java/org/rutebanken/sobek/auth/DefaultAuthorizationService.java
+++ b/sobek-service/src/main/java/org/rutebanken/sobek/auth/DefaultAuthorizationService.java
@@ -108,7 +108,7 @@ public class DefaultAuthorizationService implements AuthorizationService {
 
         Set<String> organisationRefs = new HashSet<>();
         roleAssignments.forEach(roleAssignment -> {
-            if(roleAssignment.getRole().equals(ROLE_EDIT_VEHICLE_DATA)
+            if(ROLE_EDIT_VEHICLE_DATA.equals(roleAssignment.getRole())
                     && roleAssignment.getEntityClassifications() != null) {  // Maybe return also "read" or "delete"? Review this later on, for now only "edit" is needed.
                 List<String> dataOwnersAllowed = roleAssignment.getEntityClassifications().get(CLASSIFICATION_DATA_OWNER);
                 if(dataOwnersAllowed != null) {

--- a/sobek-service/src/main/java/org/rutebanken/sobek/auth/DefaultAuthorizationService.java
+++ b/sobek-service/src/main/java/org/rutebanken/sobek/auth/DefaultAuthorizationService.java
@@ -11,11 +11,12 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import static org.rutebanken.helper.organisation.AuthorizationConstants.ENTITY_CLASSIFIER_ALL_ATTRIBUTES;
-import static org.rutebanken.sobek.auth.AuthorizationConstants.ROLE_DELETE_VEHICLE_DATA;
-import static org.rutebanken.sobek.auth.AuthorizationConstants.ROLE_EDIT_VEHICLE_DATA;
+import static org.rutebanken.sobek.auth.AuthorizationConstants.*;
 
 public class DefaultAuthorizationService implements AuthorizationService {
     private final DataScopedAuthorizationService dataScopedAuthorizationService;
@@ -98,4 +99,21 @@ public class DefaultAuthorizationService implements AuthorizationService {
 
         return dataScopedAuthorizationService.isAuthorized(role, List.of(entity));
     }
+
+    @Override
+    public List<String> getOrganisationRefsUserIsAuthorizedFor() {
+        List<RoleAssignment> roleAssignments = roleAssignmentExtractor.getRoleAssignmentsForUser();
+
+        Set<String> organisationRefs = new HashSet<>();
+        roleAssignments.forEach(roleAssignment -> {
+            if(roleAssignment.getRole().equals(ROLE_EDIT_VEHICLE_DATA)) {  // Maybe return also "read" or "delete"? Review this later on, for now only "edit" is needed.
+                List<String> dataOwnersAllowed = roleAssignment.getEntityClassifications().get(CLASSIFICATION_DATA_OWNER);
+                if(dataOwnersAllowed != null) {
+                    organisationRefs.addAll(dataOwnersAllowed.stream().map(dataOwner -> dataOwner.replace("/", ":")).toList());
+                }
+            }
+        });
+        return organisationRefs.stream().toList();
+    }
+
 }

--- a/sobek-service/src/main/java/org/rutebanken/sobek/importer/PublicationDeliveryImporter.java
+++ b/sobek-service/src/main/java/org/rutebanken/sobek/importer/PublicationDeliveryImporter.java
@@ -29,7 +29,6 @@ import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 
 import java.util.Timer;
@@ -50,8 +49,6 @@ public class PublicationDeliveryImporter {
     private final DeckPlanImportHandler deckPlanImportHandler;
     private final EquipmentImportHandler equipmentImportHandler;
     private final VehicleModelImportHandler vehicleModelImportHandler;
-    private final AuthorizationService authorizationService;
-    private final boolean authorizationEnabled;
     private final SchematicMapImportHandler schematicMapImportHandler;
     private final MappingContext mappingContext;
 
@@ -59,8 +56,7 @@ public class PublicationDeliveryImporter {
     public PublicationDeliveryImporter(PublicationDeliveryHelper publicationDeliveryHelper,
                                        PublicationDeliveryCreator publicationDeliveryCreator,
                                        VehicleImportHandler vehicleImportHandler, VehicleTypeImportHandler vehicleTypeImportHandler, DeckPlanImportHandler deckPlanImportHandler, EquipmentImportHandler equipmentImportHandler, VehicleModelImportHandler vehicleModelImportHandler,
-                                       AuthorizationService authorizationService,
-                                       @Value("${authorization.enabled:true}") boolean authorizationEnabled, SchematicMapImportHandler schematicMapImportHandler, MappingContext mappingContext) {
+                                        SchematicMapImportHandler schematicMapImportHandler, MappingContext mappingContext) {
         this.publicationDeliveryHelper = publicationDeliveryHelper;
         this.publicationDeliveryCreator = publicationDeliveryCreator;
         this.vehicleImportHandler = vehicleImportHandler;
@@ -68,16 +64,10 @@ public class PublicationDeliveryImporter {
         this.deckPlanImportHandler = deckPlanImportHandler;
         this.equipmentImportHandler = equipmentImportHandler;
         this.vehicleModelImportHandler = vehicleModelImportHandler;
-        this.authorizationService = authorizationService;
-        this.authorizationEnabled = authorizationEnabled;
         this.schematicMapImportHandler = schematicMapImportHandler;
         this.mappingContext = mappingContext;
     }
 
-
-    public PublicationDeliveryStructure importPublicationDelivery(PublicationDeliveryStructure incomingPublicationDelivery) {
-        return importPublicationDelivery(incomingPublicationDelivery, null);
-    }
 
     public PublicationDeliveryStructure importPublicationDelivery(PublicationDeliveryStructure incomingPublicationDelivery, ImportParams importParams) {
 //        if(authorizationEnabled && !authorizationService.canEditAllEntities()){

--- a/sobek-service/src/main/java/org/rutebanken/sobek/importer/PublicationDeliveryImporter.java
+++ b/sobek-service/src/main/java/org/rutebanken/sobek/importer/PublicationDeliveryImporter.java
@@ -17,7 +17,6 @@ package org.rutebanken.sobek.importer;
 
 import org.rutebanken.netex.model.PublicationDeliveryStructure;
 import org.rutebanken.netex.model.ResourceFrame;
-import org.rutebanken.sobek.auth.AuthorizationService;
 import org.rutebanken.sobek.exporter.PublicationDeliveryCreator;
 import org.rutebanken.sobek.importer.handler.*;
 import org.rutebanken.sobek.importer.log.ImportLogger;
@@ -28,7 +27,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.util.Timer;

--- a/sobek-service/src/main/java/org/rutebanken/sobek/importer/PublicationDeliveryImporter.java
+++ b/sobek-service/src/main/java/org/rutebanken/sobek/importer/PublicationDeliveryImporter.java
@@ -80,9 +80,9 @@ public class PublicationDeliveryImporter {
     }
 
     public PublicationDeliveryStructure importPublicationDelivery(PublicationDeliveryStructure incomingPublicationDelivery, ImportParams importParams) {
-        if(authorizationEnabled && !authorizationService.canEditAllEntities()){
-            throw new AccessDeniedException("Insufficient privileges for operation");
-        }
+//        if(authorizationEnabled && !authorizationService.canEditAllEntities()){
+//            throw new AccessDeniedException("Insufficient privileges for operation");
+//        }
 
 
         if (incomingPublicationDelivery.getDataObjects() == null) {

--- a/sobek-service/src/main/java/org/rutebanken/sobek/importer/PublicationDeliveryImporter.java
+++ b/sobek-service/src/main/java/org/rutebanken/sobek/importer/PublicationDeliveryImporter.java
@@ -111,7 +111,7 @@ public class PublicationDeliveryImporter {
         // Currently only supporting one resource frame per publication delivery
         ResourceFrame netexResourceFrame = publicationDeliveryHelper.findResourceFrame(incomingPublicationDelivery);
 
-        mappingContext.updateMappingContext(incomingPublicationDelivery);
+        mappingContext.updateMappingContext(incomingPublicationDelivery, netexResourceFrame);
 
         ResourceFrame responseResourceFrame = null;
         if(netexResourceFrame != null) {

--- a/sobek-service/src/main/java/org/rutebanken/sobek/importer/PublicationDeliveryImporter.java
+++ b/sobek-service/src/main/java/org/rutebanken/sobek/importer/PublicationDeliveryImporter.java
@@ -70,10 +70,6 @@ public class PublicationDeliveryImporter {
 
 
     public PublicationDeliveryStructure importPublicationDelivery(PublicationDeliveryStructure incomingPublicationDelivery, ImportParams importParams) {
-//        if(authorizationEnabled && !authorizationService.canEditAllEntities()){
-//            throw new AccessDeniedException("Insufficient privileges for operation");
-//        }
-
 
         if (incomingPublicationDelivery.getDataObjects() == null) {
             String responseMessage = "Received publication delivery but it does not contain any data objects.";

--- a/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/context/MappingContext.java
+++ b/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/context/MappingContext.java
@@ -106,7 +106,7 @@ public class MappingContext {
         logger.info("Setting default time zone for netex mapping context to {}", this.defaultTimeZone);
     }
 
-    public void updateMappingContext(PublicationDeliveryStructure publicationDeliveryStructure) {
+    public void updateMappingContext(PublicationDeliveryStructure publicationDeliveryStructure, ResourceFrame resourceFrame) {
         // Check what kind of frame we find
         List<JAXBElement<? extends Common_VersionFrameStructure>> compositeFrameOrCommonFrame = publicationDeliveryStructure.getDataObjects().getCompositeFrameOrCommonFrame();
 
@@ -127,6 +127,47 @@ public class MappingContext {
         String timeZoneString = defaults.getDefaultLocale().getTimeZone();
 
         this.defaultTimeZone = ZoneId.of(timeZoneString);
+
+        ResponsibilitySetsInFrame_RelStructure responsibilitySets = resourceFrame.getResponsibilitySets();
+
+        if (responsibilitySets == null || responsibilitySets.getResponsibilitySet() == null) {
+            throw new NetexMappingException("Cannot resolve responsibilitysets from resourceframe " + resourceFrame.getId());
+        }
+
+        ResponsibilitySet responsibilitySet = responsibilitySets.getResponsibilitySet().getFirst();
+        if (responsibilitySet == null) {
+            throw new NetexMappingException("Cannot resolve responsibilityset from resourceframe " + resourceFrame.getId());
+        }
+
+        if(responsibilitySet.getRoles() == null ||
+                responsibilitySet.getRoles().getResponsibilityRoleAssignment() == null ||
+                responsibilitySet.getRoles().getResponsibilityRoleAssignment().isEmpty()) {
+            throw new NetexMappingException("Cannot resolve role from responsibilityset " + responsibilitySet.getId());
+        }
+
+        ResponsibilityRoleAssignment roleAssignment = responsibilitySet.getRoles()
+                                .getResponsibilityRoleAssignment()
+                                .stream()
+                                .filter(ra -> ra.getDataRoleType().contains(DataRoleTypeEnumeration.OWNS))
+                                .findFirst()
+                                .orElseThrow(() -> new NetexMappingException("Cannot resolve dataowner role from responsibilityset " + responsibilitySet.getId()));
+
+        if(roleAssignment.getResponsibleOrganisationRef() == null || roleAssignment.getResponsibleOrganisationRef().getRef() == null) {
+            throw new NetexMappingException("Cannot resolve responsible organisation from responsibilityset " + responsibilitySet.getId());
+        }
+
+        if(defaults.getDefaultResponsibilitySetRef() == null || defaults.getDefaultResponsibilitySetRef().getRef() == null) {
+            throw new NetexMappingException("Cannot resolve default responsibilityset from FrameDefaults");
+        }
+
+        if(!responsibilitySet.getId().equals(defaults.getDefaultResponsibilitySetRef().getRef())) {
+            throw new NetexMappingException("Default responsibilitysetref " + defaults.getDefaultResponsibilitySetRef().getRef() + " doesn't match to a valid responsibilityset");
+        }
+
+        this.ownedEntityMapper.setDataOwnerRef(roleAssignment.getResponsibleOrganisationRef().getRef());
+
+
+
         logger.info("Setting default time zone for netex mapping context to {}", this.defaultTimeZone);
     }
 }

--- a/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/context/MappingContext.java
+++ b/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/context/MappingContext.java
@@ -132,7 +132,19 @@ public class MappingContext {
             throw new NetexMappingException("Cannot resolve responsibilitysets from resourceframe " + resourceFrame.getId());
         }
 
-        ResponsibilitySet responsibilitySet = responsibilitySets.getResponsibilitySet().getFirst();
+        if(defaults.getDefaultResponsibilitySetRef() == null || defaults.getDefaultResponsibilitySetRef().getRef() == null) {
+            throw new NetexMappingException("Cannot resolve default responsibilityset from FrameDefaults");
+        }
+
+        String responsibilitySetRef = defaults.getDefaultResponsibilitySetRef().getRef();
+
+        ResponsibilitySet responsibilitySet = responsibilitySets
+                .getResponsibilitySet()
+                .stream()
+                .filter(rs -> rs.getId().equals(responsibilitySetRef))
+                .findFirst()
+                .orElse(null);
+
         if (responsibilitySet == null) {
             throw new NetexMappingException("Cannot resolve responsibilityset from resourceframe " + resourceFrame.getId());
         }
@@ -152,10 +164,6 @@ public class MappingContext {
 
         if(roleAssignment.getResponsibleOrganisationRef() == null || roleAssignment.getResponsibleOrganisationRef().getRef() == null) {
             throw new NetexMappingException("Cannot resolve responsible organisation from responsibilityset " + responsibilitySet.getId());
-        }
-
-        if(defaults.getDefaultResponsibilitySetRef() == null || defaults.getDefaultResponsibilitySetRef().getRef() == null) {
-            throw new NetexMappingException("Cannot resolve default responsibilityset from FrameDefaults");
         }
 
         if(!responsibilitySet.getId().equals(defaults.getDefaultResponsibilitySetRef().getRef())) {

--- a/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/context/MappingContext.java
+++ b/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/context/MappingContext.java
@@ -95,17 +95,6 @@ public class MappingContext {
         this.ownedEntityMapper = ownedEntityMapper;
     }
 
-    public void updateMappingContext(SiteFrame netexSiteFrame) {
-        String timeZoneString = Optional.of(netexSiteFrame)
-                .map(SiteFrame::getFrameDefaults)
-                .map(VersionFrameDefaultsStructure::getDefaultLocale)
-                .map(LocaleStructure::getTimeZone)
-                .orElseThrow(() -> new NetexMappingException("Cannot resolve time zone from FrameDefaults in site frame " + netexSiteFrame.getId()));
-
-        this.defaultTimeZone = ZoneId.of(timeZoneString);
-        logger.info("Setting default time zone for netex mapping context to {}", this.defaultTimeZone);
-    }
-
     public void updateMappingContext(PublicationDeliveryStructure publicationDeliveryStructure, ResourceFrame resourceFrame) {
         // Check what kind of frame we find
         List<JAXBElement<? extends Common_VersionFrameStructure>> compositeFrameOrCommonFrame = publicationDeliveryStructure.getDataObjects().getCompositeFrameOrCommonFrame();

--- a/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/context/MappingContext.java
+++ b/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/context/MappingContext.java
@@ -126,7 +126,9 @@ public class MappingContext {
 
         ResponsibilitySetsInFrame_RelStructure responsibilitySets = resourceFrame.getResponsibilitySets();
 
-        if (responsibilitySets == null || responsibilitySets.getResponsibilitySet() == null) {
+        if (responsibilitySets == null ||
+                responsibilitySets.getResponsibilitySet() == null ||
+                responsibilitySets.getResponsibilitySet().isEmpty()) {
             throw new NetexMappingException("Cannot resolve responsibilitysets from resourceframe " + resourceFrame.getId());
         }
 

--- a/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/context/MappingContext.java
+++ b/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/context/MappingContext.java
@@ -58,6 +58,7 @@ public class MappingContext {
     private NetexIdHelper netexIdHelper;
     private DataManagedObjectStructureMapper dataManagedObjectStructureMapper;
     private OwnedEntityMapper ownedEntityMapper;
+    private String dataOwnerRef;
 
     public MappingContext() {
     }
@@ -109,7 +110,9 @@ public class MappingContext {
             throw new NetexMappingException("Cannot resolve time zone from FrameDefaults in frame " + compositeFrameOrCommonFrame.getFirst().getValue().getId());
         }
 
-        if(defaults == null) {
+        if(defaults == null ||
+                defaults.getDefaultLocale() == null ||
+                defaults.getDefaultLocale().getTimeZone() == null) {
             throw new NetexMappingException("Cannot resolve time zone from FrameDefaults in frame " + compositeFrameOrCommonFrame.getFirst().getValue().getId());
         }
 
@@ -153,7 +156,7 @@ public class MappingContext {
             throw new NetexMappingException("Default responsibilitysetref " + defaults.getDefaultResponsibilitySetRef().getRef() + " doesn't match to a valid responsibilityset");
         }
 
-        this.ownedEntityMapper.setDataOwnerRef(roleAssignment.getResponsibleOrganisationRef().getRef());
+        this.setDataOwnerRef(roleAssignment.getResponsibleOrganisationRef().getRef());
 
 
 

--- a/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/context/MappingContext.java
+++ b/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/context/MappingContext.java
@@ -120,6 +120,10 @@ public class MappingContext {
 
         this.defaultTimeZone = ZoneId.of(timeZoneString);
 
+        if(resourceFrame == null) {
+            throw new NetexMappingException("There is no ResourceFrame in the publication delivery");
+        }
+
         ResponsibilitySetsInFrame_RelStructure responsibilitySets = resourceFrame.getResponsibilitySets();
 
         if (responsibilitySets == null || responsibilitySets.getResponsibilitySet() == null) {

--- a/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/context/MappingContext.java
+++ b/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/context/MappingContext.java
@@ -12,6 +12,7 @@ import org.rutebanken.sobek.netex.id.ValidPrefixList;
 import org.rutebanken.sobek.netex.mapping.NetexMappingException;
 import org.rutebanken.sobek.netex.mapping.mapstruct.DataManagedObjectStructureMapper;
 import org.rutebanken.sobek.netex.mapping.mapstruct.KeyListStructureMapper;
+import org.rutebanken.sobek.netex.mapping.mapstruct.OwnedEntityMapper;
 import org.rutebanken.sobek.netex.mapping.mapstruct.deckplan.DeckSpaceMapper;
 import org.rutebanken.sobek.netex.mapping.mapstruct.deckplan.SpotAffinityMapper;
 import org.rutebanken.sobek.netex.mapping.mapstruct.equipment.*;
@@ -56,6 +57,7 @@ public class MappingContext {
     private ValidPrefixList validPrefixList;
     private NetexIdHelper netexIdHelper;
     private DataManagedObjectStructureMapper dataManagedObjectStructureMapper;
+    private OwnedEntityMapper ownedEntityMapper;
 
     public MappingContext() {
     }
@@ -74,7 +76,8 @@ public class MappingContext {
                           SpotAffinityMapper spotAffinityMapper,
                           ValidPrefixList validPrefixList,
                           NetexIdHelper netexIdHelper,
-                          DataManagedObjectStructureMapper dataManagedObjectStructureMapper) {
+                          DataManagedObjectStructureMapper dataManagedObjectStructureMapper,
+                          OwnedEntityMapper ownedEntityMapper) {
         this.referenceResolver = resolver;
         this.seatEquipmentMapper = seatEquipmentMapper;
         this.bedEquipmentMapper = bedEquipmentMapper;
@@ -89,6 +92,7 @@ public class MappingContext {
         this.validPrefixList = validPrefixList;
         this.netexIdHelper = netexIdHelper;
         this.dataManagedObjectStructureMapper = dataManagedObjectStructureMapper;
+        this.ownedEntityMapper = ownedEntityMapper;
     }
 
     public void updateMappingContext(SiteFrame netexSiteFrame) {

--- a/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/mapstruct/OwnedEntityMapper.java
+++ b/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/mapstruct/OwnedEntityMapper.java
@@ -1,7 +1,5 @@
 package org.rutebanken.sobek.netex.mapping.mapstruct;
 
-import org.mapstruct.Context;
-import org.mapstruct.MappingTarget;
 import org.rutebanken.sobek.model.authorization.OwnedEntity;
 import org.rutebanken.sobek.netex.mapping.context.MappingContext;
 import org.springframework.stereotype.Service;
@@ -10,8 +8,8 @@ import org.springframework.stereotype.Service;
 public class OwnedEntityMapper {
 
     public void updateSobekFromNetex(
-            @MappingTarget OwnedEntity target,
-            @Context MappingContext context
+            OwnedEntity target,
+            MappingContext context
     ) {
         if (target != null) {
             target.setDataOwnerRef(context.getDataOwnerRef());

--- a/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/mapstruct/OwnedEntityMapper.java
+++ b/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/mapstruct/OwnedEntityMapper.java
@@ -2,16 +2,11 @@ package org.rutebanken.sobek.netex.mapping.mapstruct;
 
 import lombok.Getter;
 import lombok.Setter;
-import org.mapstruct.Context;
-import org.mapstruct.Mapper;
 import org.mapstruct.MappingTarget;
 import org.rutebanken.sobek.model.authorization.OwnedEntity;
-import org.rutebanken.sobek.netex.mapping.config.SobekMapperConfig;
-import org.rutebanken.sobek.netex.mapping.context.MappingContext;
+import org.springframework.stereotype.Service;
 
-@Mapper(
-        config = SobekMapperConfig.class
-)
+@Service
 @Getter
 @Setter
 public class OwnedEntityMapper {
@@ -19,9 +14,7 @@ public class OwnedEntityMapper {
     private String dataOwnerRef;
 
     public void updateSobekFromNetex(
-            org.rutebanken.netex.model.DataManagedObjectStructure source,
-            @MappingTarget OwnedEntity target,
-            @Context MappingContext context
+            @MappingTarget OwnedEntity target
     ) {
         if (target != null) {
             target.setDataOwnerRef(dataOwnerRef);

--- a/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/mapstruct/OwnedEntityMapper.java
+++ b/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/mapstruct/OwnedEntityMapper.java
@@ -1,5 +1,7 @@
 package org.rutebanken.sobek.netex.mapping.mapstruct;
 
+import lombok.Getter;
+import lombok.Setter;
 import org.mapstruct.Context;
 import org.mapstruct.Mapper;
 import org.mapstruct.MappingTarget;
@@ -10,14 +12,19 @@ import org.rutebanken.sobek.netex.mapping.context.MappingContext;
 @Mapper(
         config = SobekMapperConfig.class
 )
+@Getter
+@Setter
 public class OwnedEntityMapper {
+
+    private String dataOwnerRef;
+
     public void updateSobekFromNetex(
             org.rutebanken.netex.model.DataManagedObjectStructure source,
             @MappingTarget OwnedEntity target,
             @Context MappingContext context
     ) {
         if (target != null) {
-            target.setDataOwnerRef("NOG:Authority:cP4aPiJ7c39");  // Temporary - set all entities to be owned by ATB
+            target.setDataOwnerRef(dataOwnerRef);
         }
     }
 }

--- a/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/mapstruct/OwnedEntityMapper.java
+++ b/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/mapstruct/OwnedEntityMapper.java
@@ -1,23 +1,20 @@
 package org.rutebanken.sobek.netex.mapping.mapstruct;
 
-import lombok.Getter;
-import lombok.Setter;
+import org.mapstruct.Context;
 import org.mapstruct.MappingTarget;
 import org.rutebanken.sobek.model.authorization.OwnedEntity;
+import org.rutebanken.sobek.netex.mapping.context.MappingContext;
 import org.springframework.stereotype.Service;
 
 @Service
-@Getter
-@Setter
 public class OwnedEntityMapper {
 
-    private String dataOwnerRef;
-
     public void updateSobekFromNetex(
-            @MappingTarget OwnedEntity target
+            @MappingTarget OwnedEntity target,
+            @Context MappingContext context
     ) {
         if (target != null) {
-            target.setDataOwnerRef(dataOwnerRef);
+            target.setDataOwnerRef(context.getDataOwnerRef());
         }
     }
 }

--- a/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/mapstruct/OwnedEntityMapper.java
+++ b/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/mapstruct/OwnedEntityMapper.java
@@ -1,0 +1,23 @@
+package org.rutebanken.sobek.netex.mapping.mapstruct;
+
+import org.mapstruct.Context;
+import org.mapstruct.Mapper;
+import org.mapstruct.MappingTarget;
+import org.rutebanken.sobek.model.authorization.OwnedEntity;
+import org.rutebanken.sobek.netex.mapping.config.SobekMapperConfig;
+import org.rutebanken.sobek.netex.mapping.context.MappingContext;
+
+@Mapper(
+        config = SobekMapperConfig.class
+)
+public class OwnedEntityMapper {
+    public void updateSobekFromNetex(
+            org.rutebanken.netex.model.DataManagedObjectStructure source,
+            @MappingTarget OwnedEntity target,
+            @Context MappingContext context
+    ) {
+        if (target != null) {
+            target.setDataOwnerRef("NOG:Authority:cP4aPiJ7c39");  // Temporary - set all entities to be owned by ATB
+        }
+    }
+}

--- a/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/mapstruct/VehicleMapper.java
+++ b/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/mapstruct/VehicleMapper.java
@@ -125,6 +125,7 @@ public interface VehicleMapper {
                 target.setVehicleModel(vehicleModel);
             }
         }
+        context.getOwnedEntityMapper().updateSobekFromNetex(source, target, context);
     }
 
     /**

--- a/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/mapstruct/VehicleMapper.java
+++ b/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/mapstruct/VehicleMapper.java
@@ -125,7 +125,7 @@ public interface VehicleMapper {
                 target.setVehicleModel(vehicleModel);
             }
         }
-        context.getOwnedEntityMapper().updateSobekFromNetex(source, target, context);
+        context.getOwnedEntityMapper().updateSobekFromNetex(target);
     }
 
     /**

--- a/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/mapstruct/VehicleMapper.java
+++ b/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/mapstruct/VehicleMapper.java
@@ -125,7 +125,7 @@ public interface VehicleMapper {
                 target.setVehicleModel(vehicleModel);
             }
         }
-        context.getOwnedEntityMapper().updateSobekFromNetex(target);
+        context.getOwnedEntityMapper().updateSobekFromNetex(target, context);
     }
 
     /**

--- a/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/mapstruct/VehicleTypeMapper.java
+++ b/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/mapstruct/VehicleTypeMapper.java
@@ -102,7 +102,7 @@ public interface VehicleTypeMapper {
                 target.setDeckPlan(deckPlan);
             }
         }
-        context.getOwnedEntityMapper().updateSobekFromNetex(target);
+        context.getOwnedEntityMapper().updateSobekFromNetex(target, context);
     }
 
     /**

--- a/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/mapstruct/VehicleTypeMapper.java
+++ b/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/mapstruct/VehicleTypeMapper.java
@@ -102,7 +102,7 @@ public interface VehicleTypeMapper {
                 target.setDeckPlan(deckPlan);
             }
         }
-        context.getOwnedEntityMapper().updateSobekFromNetex(source, target, context);
+        context.getOwnedEntityMapper().updateSobekFromNetex(target);
     }
 
     /**

--- a/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/mapstruct/VehicleTypeMapper.java
+++ b/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/mapstruct/VehicleTypeMapper.java
@@ -102,6 +102,7 @@ public interface VehicleTypeMapper {
                 target.setDeckPlan(deckPlan);
             }
         }
+        context.getOwnedEntityMapper().updateSobekFromNetex(source, target, context);
     }
 
     /**

--- a/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/mapstruct/deckplan/DeckPlanMapper.java
+++ b/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/mapstruct/deckplan/DeckPlanMapper.java
@@ -66,6 +66,7 @@ public interface DeckPlanMapper {
         if(target != null) {
             context.getDataManagedObjectStructureMapper().afterMappingToSobek(source, target, context);
         }
+        context.getOwnedEntityMapper().updateSobekFromNetex(source, target, context);
     }
 
     /**

--- a/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/mapstruct/deckplan/DeckPlanMapper.java
+++ b/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/mapstruct/deckplan/DeckPlanMapper.java
@@ -66,7 +66,7 @@ public interface DeckPlanMapper {
         if(target != null) {
             context.getDataManagedObjectStructureMapper().afterMappingToSobek(source, target, context);
         }
-        context.getOwnedEntityMapper().updateSobekFromNetex(source, target, context);
+        context.getOwnedEntityMapper().updateSobekFromNetex(target);
     }
 
     /**

--- a/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/mapstruct/deckplan/DeckPlanMapper.java
+++ b/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/mapstruct/deckplan/DeckPlanMapper.java
@@ -66,7 +66,7 @@ public interface DeckPlanMapper {
         if(target != null) {
             context.getDataManagedObjectStructureMapper().afterMappingToSobek(source, target, context);
         }
-        context.getOwnedEntityMapper().updateSobekFromNetex(target);
+        context.getOwnedEntityMapper().updateSobekFromNetex(target, context);
     }
 
     /**

--- a/sobek-service/src/test/java/org/rutebanken/sobek/auth/DummyAuthorizationService.java
+++ b/sobek-service/src/test/java/org/rutebanken/sobek/auth/DummyAuthorizationService.java
@@ -4,6 +4,7 @@ import org.rutebanken.sobek.model.EntityStructure;
 import org.springframework.stereotype.Service;
 
 import java.util.Collection;
+import java.util.List;
 
 @Service
 public class DummyAuthorizationService implements AuthorizationService {
@@ -41,4 +42,8 @@ public class DummyAuthorizationService implements AuthorizationService {
     public boolean isGuest() {
         return false;
     }
+
+    @Override
+    public List<String> getOrganisationRefsUserIsAuthorizedFor() { return null; }
+
 }

--- a/sobek-service/src/test/java/org/rutebanken/sobek/netex/mapping/mapstruct/VehicleMapperTest.java
+++ b/sobek-service/src/test/java/org/rutebanken/sobek/netex/mapping/mapstruct/VehicleMapperTest.java
@@ -58,6 +58,7 @@ class VehicleMapperTest {
 
         VehicleType mockVehicleType = new VehicleType();
         mockVehicleType.setNetexId("NMR:VehicleType:1");
+        mockVehicleType.setDataOwnerRef("NOG:Authority:1");
 
         ReferenceResolver referenceResolver = mock(ReferenceResolver.class);
         when(referenceResolver.resolve(any(),any(),eq(VehicleType.class))).thenReturn(mockVehicleType);

--- a/sobek-service/src/test/java/org/rutebanken/sobek/netex/mapping/mapstruct/VehicleMapperTest.java
+++ b/sobek-service/src/test/java/org/rutebanken/sobek/netex/mapping/mapstruct/VehicleMapperTest.java
@@ -42,6 +42,8 @@ class VehicleMapperTest {
     private ValidPrefixList validPrefixList;
     @Autowired
     private DataManagedObjectStructureMapper dataManagedObjectStructureMapper;
+    @Autowired
+    private OwnedEntityMapper ownedEntityMapper;
 
     @Test
     void testMapperIsInjected() {
@@ -66,6 +68,7 @@ class VehicleMapperTest {
         mappingContext.setNetexIdHelper(netexIdHelper);
         mappingContext.setValidPrefixList(validPrefixList);
         mappingContext.setDataManagedObjectStructureMapper(dataManagedObjectStructureMapper);
+        mappingContext.setOwnedEntityMapper(ownedEntityMapper);
     }
 
     @Test

--- a/sobek-service/src/test/java/org/rutebanken/sobek/netex/mapping/mapstruct/VehicleMapperTest.java
+++ b/sobek-service/src/test/java/org/rutebanken/sobek/netex/mapping/mapstruct/VehicleMapperTest.java
@@ -69,6 +69,7 @@ class VehicleMapperTest {
         mappingContext.setValidPrefixList(validPrefixList);
         mappingContext.setDataManagedObjectStructureMapper(dataManagedObjectStructureMapper);
         mappingContext.setOwnedEntityMapper(ownedEntityMapper);
+        mappingContext.setDataOwnerRef("NOG:Authority:1");
     }
 
     @Test
@@ -105,6 +106,7 @@ class VehicleMapperTest {
         assertEquals("CHASSIS123", sobekVehicle.getChassisNumber());
         assertEquals("OP456", sobekVehicle.getOperationalNumber());
         assertEquals(temporalTypeMapper.localDateTimeToInstant(LocalDateTime.of(2023, 1, 15, 0, 0)), sobekVehicle.getRegistrationDate());
+        assertEquals("NOG:Authority:1", sobekVehicle.getDataOwnerRef());
 
         // Check that references are stored in transient fields
         assertNotNull(sobekVehicle.getVehicleModel());
@@ -112,6 +114,7 @@ class VehicleMapperTest {
 
         assertNotNull(sobekVehicle.getTransportType());
         assertEquals("NMR:VehicleType:1", sobekVehicle.getTransportType().getNetexId());
+        assertEquals("NOG:Authority:1", sobekVehicle.getTransportType().getDataOwnerRef());
     }
 
     @Test


### PR DESCRIPTION
### Summary

Add authorization to Sobek:
- Mutations require dataOwnerRef, which needs to be a reference to an Organisation
- GraphQL fetches require dataOwnerRef in the filter
- NeTEx import requires that FrameDefaults refer to a responsibilityset, which in turn includes reference to dataOwner

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to documentation only)
- [ ] Other (please describe)