### PR TITLE
Feature/add environment properties as native and refine mutations

### DIFF
--- a/sobek-app/src/main/resources/db/migration/V9__Add_environmental_properties_as_native_properties.sql
+++ b/sobek-app/src/main/resources/db/migration/V9__Add_environmental_properties_as_native_properties.sql
@@ -1,0 +1,29 @@
+ALTER TABLE train
+    ADD form_drag_coefficient DECIMAL;
+
+ALTER TABLE train
+    ADD fuel_types VARCHAR(255);
+
+ALTER TABLE train
+    ADD hybrid_category SMALLINT;
+
+ALTER TABLE train
+    ADD maximum_engine_effectkw DECIMAL;
+
+ALTER TABLE train
+    ADD propulsion_types VARCHAR(255);
+
+ALTER TABLE train
+    ADD roll_resistance_coefficient DECIMAL;
+
+ALTER TABLE vehicle_type
+    ADD form_drag_coefficient DECIMAL;
+
+ALTER TABLE vehicle_type
+    ADD hybrid_category SMALLINT;
+
+ALTER TABLE vehicle_type
+    ADD maximum_engine_effectkw DECIMAL;
+
+ALTER TABLE vehicle_type
+    ADD roll_resistance_coefficient DECIMAL;

--- a/sobek-app/src/main/resources/db/migration/V9__Add_environmental_properties_as_native_properties.sql
+++ b/sobek-app/src/main/resources/db/migration/V9__Add_environmental_properties_as_native_properties.sql
@@ -5,7 +5,7 @@ ALTER TABLE train
     ADD fuel_types VARCHAR(255);
 
 ALTER TABLE train
-    ADD hybrid_category SMALLINT;
+    ADD hybrid_category VARCHAR(255);
 
 ALTER TABLE train
     ADD maximum_engine_effectkw DECIMAL;
@@ -20,7 +20,7 @@ ALTER TABLE vehicle_type
     ADD form_drag_coefficient DECIMAL;
 
 ALTER TABLE vehicle_type
-    ADD hybrid_category SMALLINT;
+    ADD hybrid_category VARCHAR(255);
 
 ALTER TABLE vehicle_type
     ADD maximum_engine_effectkw DECIMAL;

--- a/sobek-app/src/test/java/org/rutebanken/sobek/rest/graphql/GraphQLPagedQueriesTest.java
+++ b/sobek-app/src/test/java/org/rutebanken/sobek/rest/graphql/GraphQLPagedQueriesTest.java
@@ -142,7 +142,7 @@ class GraphQLPagedQueriesTest {
     void vehicleTypes_exposesNewFields() {
         given()
             .contentType(ContentType.JSON)
-            .body(gql("{ vehicleTypes(page: 0, size: 100, filter: { transportModes: [ BUS ]  dataOwnerRef: \"NOG:Authority:cP4aPiJ7c39\" } ) { content { netexId, description { value }, name { value }, version, euroClass, passengerCapacity { totalCapacity, standingCapacity, seatingCapacity },  transportMode, created, fuelTypes, propulsionTypes, privateCode { type, value}, formDragCoefficient, maximumRange, length, height, width, weight, vehicles { chassisNumber, netexId, registrationNumber }  } totalElements page size } }"))
+            .body(gql("{ vehicleTypes(page: 0, size: 100, filter: { transportModes: [ BUS ] netexIds: [\"AKT:VehicleType:123\"] dataOwnerRef: \"NOG:Authority:cP4aPiJ7c39\" } ) { content { netexId, description { value }, name { value }, version, euroClass, passengerCapacity { totalCapacity, standingCapacity, seatingCapacity },  transportMode, created, fuelTypes, propulsionTypes, privateCode { type, value}, formDragCoefficient, maximumRange, length, height, width, weight, vehicles { chassisNumber, netexId, registrationNumber }  } totalElements page size } }"))
                 .when()
             .post("/services/vehicles/graphql")
         .then()

--- a/sobek-app/src/test/java/org/rutebanken/sobek/rest/netex/VehicleTypeImportIT.java
+++ b/sobek-app/src/test/java/org/rutebanken/sobek/rest/netex/VehicleTypeImportIT.java
@@ -83,7 +83,7 @@ class VehicleTypeImportIT {
                 () ->
                     new AssertionError(
                         "No TextType name element in imported vehicle type"));
-    assertThat(nameText.getValue()).isEqualTo("Exqui City 24");
+    assertThat(nameText.getValue()).isEqualTo("Exaqui City 24");
   }
 
     @Test
@@ -124,7 +124,6 @@ class VehicleTypeImportIT {
                         responseFrame.getVehicleTypes().getTransportType_Dummy().getFirst().getValue();
 
         assertThat(imported.getId()).startsWith("AKT:VehicleType:");
-        assertThat(imported.getVersion()).isEqualTo("1");
         assertThat(imported.getName().getContent()).hasSize(3);
         assertThat(imported.getName().getContent().get(1)).isInstanceOf(JAXBElement.class);
         JAXBElement<? extends  TextType> theName = (JAXBElement)imported.getName().getContent().get(1);

--- a/sobek-app/src/test/resources/fixtures/vehicle-type-import-1.xml
+++ b/sobek-app/src/test/resources/fixtures/vehicle-type-import-1.xml
@@ -22,7 +22,7 @@
             </responsibilitySets>
             <vehicleTypes>
                 <VehicleType version="1" id="TST:VehicleType:1" >
-                    <Name><Text>Exqui City 24</Text></Name>
+                    <Name><Text>Exbqui City 24</Text></Name>
                     <Description><Text>Van Hool articulated electric bus</Text></Description>
                     <EuroClass>Euro6</EuroClass>
                     <SelfPropelled>true</SelfPropelled>

--- a/sobek-app/src/test/resources/fixtures/vehicle-type-import.xml
+++ b/sobek-app/src/test/resources/fixtures/vehicle-type-import.xml
@@ -22,7 +22,7 @@
             </responsibilitySets>
             <vehicleTypes>
                 <VehicleType version="1" id="TST:VehicleType:1" >
-                    <Name><Text>Exqui City 24</Text></Name>
+                    <Name><Text>Exaqui City 24</Text></Name>
                     <Description><Text>Van Hool articulated electric bus</Text></Description>
                     <EuroClass>Euro6</EuroClass>
                     <SelfPropelled>true</SelfPropelled>

--- a/sobek-common/src/main/java/org/rutebanken/sobek/netex/util/KeyValuesHelper.java
+++ b/sobek-common/src/main/java/org/rutebanken/sobek/netex/util/KeyValuesHelper.java
@@ -19,7 +19,7 @@ public class KeyValuesHelper {
         existing.ifPresentOrElse(keyValueStructure -> keyValueStructure.setValue(value), () -> objectWithKeyValues.getKeyList().getKeyValue().add(new KeyValueStructure().withKey(propertyName).withValue(value)));
     }
 
-    public static <ObjectType, PropertyType> void SetFromKeyValues(ObjectType target, String propertyName, KeyListStructure keyList, Function<String, PropertyType> convertFunction, Consumer<PropertyType> setFunction) {
+    public static <PropertyType> void SetFromKeyValues(String propertyName, KeyListStructure keyList, Function<String, PropertyType> convertFunction, Consumer<PropertyType> setFunction) {
         if(keyList == null) {
             setFunction.accept(null);
             return;

--- a/sobek-common/src/main/java/org/rutebanken/sobek/netex/util/KeyValuesHelper.java
+++ b/sobek-common/src/main/java/org/rutebanken/sobek/netex/util/KeyValuesHelper.java
@@ -10,12 +10,17 @@ import java.util.function.Function;
 
 public class KeyValuesHelper {
 
-    public static void AddToKeyValues(DataManagedObjectStructure objectWithKeyValues, String propertyName, String value) {
+    public static void SetToKeyValues(DataManagedObjectStructure objectWithKeyValues, String propertyName, String value) {
         if(objectWithKeyValues.getKeyList() == null) {
             objectWithKeyValues.setKeyList(new KeyListStructure());
         }
 
         Optional<KeyValueStructure> existing = objectWithKeyValues.getKeyList().getKeyValue().stream().filter(kv -> kv.getKey().equals(propertyName)).findFirst();
+        // A keyvalue with value == null is not allowed according to the XSD, so we remove it if it exists.
+        if(value == null) {
+            existing.ifPresent(objectWithKeyValues.getKeyList().getKeyValue()::remove);
+            return;
+        }
         existing.ifPresentOrElse(keyValueStructure -> keyValueStructure.setValue(value), () -> objectWithKeyValues.getKeyList().getKeyValue().add(new KeyValueStructure().withKey(propertyName).withValue(value)));
     }
 

--- a/sobek-common/src/main/java/org/rutebanken/sobek/netex/util/KeyValuesHelper.java
+++ b/sobek-common/src/main/java/org/rutebanken/sobek/netex/util/KeyValuesHelper.java
@@ -5,15 +5,37 @@ import org.rutebanken.netex.model.KeyListStructure;
 import org.rutebanken.netex.model.KeyValueStructure;
 
 import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.Function;
 
 public class KeyValuesHelper {
 
-    public static void AddToKeyValues(DataManagedObjectStructure objectWithKeyValues, String uniqueKey, String value) {
+    public static void AddToKeyValues(DataManagedObjectStructure objectWithKeyValues, String propertyName, String value) {
         if(objectWithKeyValues.getKeyList() == null) {
             objectWithKeyValues.setKeyList(new KeyListStructure());
         }
 
-        Optional<KeyValueStructure> existing = objectWithKeyValues.getKeyList().getKeyValue().stream().filter(kv -> kv.getKey().equals(uniqueKey)).findFirst();
-        existing.ifPresentOrElse(keyValueStructure -> keyValueStructure.setValue(value), () -> objectWithKeyValues.getKeyList().getKeyValue().add(new KeyValueStructure().withKey(uniqueKey).withValue(value)));
+        Optional<KeyValueStructure> existing = objectWithKeyValues.getKeyList().getKeyValue().stream().filter(kv -> kv.getKey().equals(propertyName)).findFirst();
+        existing.ifPresentOrElse(keyValueStructure -> keyValueStructure.setValue(value), () -> objectWithKeyValues.getKeyList().getKeyValue().add(new KeyValueStructure().withKey(propertyName).withValue(value)));
+    }
+
+    public static <ObjectType, PropertyType> void SetFromKeyValues(ObjectType target, String propertyName, KeyListStructure keyList, Function<String, PropertyType> convertFunction, Consumer<PropertyType> setFunction) {
+        if(keyList == null) {
+            setFunction.accept(null);
+            return;
+        }
+
+        var value = keyList.getKeyValue().stream().filter(kv -> kv.getKey().equals(propertyName)).findFirst();
+        if(!value.isPresent()) {
+            setFunction.accept(null);
+            return;
+        }
+
+        if(value.get().getValue() == null) {
+            setFunction.accept(null);
+            return;
+        }
+
+        setFunction.accept(convertFunction.apply(value.get().getValue()));
     }
 }

--- a/sobek-model/src/main/java/org/rutebanken/sobek/model/vehicle/VehicleType_VersionStructure.java
+++ b/sobek-model/src/main/java/org/rutebanken/sobek/model/vehicle/VehicleType_VersionStructure.java
@@ -27,6 +27,11 @@ public class VehicleType_VersionStructure extends TransportType_VersionStructure
     @Transient
     private VehicleTypeRefStructure includedIn;
 
+    private BigDecimal formDragCoefficient;
+    private BigDecimal rollResistanceCoefficient;
+    private BigDecimal maximumEngineEffectKW;
+    private HybridCategoryEnumeration hybridCategory;
+
     @Transient
     private VehicleModelRefStructure classifiedAsRef;
     @Transient

--- a/sobek-model/src/main/java/org/rutebanken/sobek/model/vehicle/VehicleType_VersionStructure.java
+++ b/sobek-model/src/main/java/org/rutebanken/sobek/model/vehicle/VehicleType_VersionStructure.java
@@ -1,5 +1,7 @@
 package org.rutebanken.sobek.model.vehicle;
 
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.MappedSuperclass;
 import jakarta.persistence.Transient;
 import lombok.Getter;
@@ -30,6 +32,7 @@ public class VehicleType_VersionStructure extends TransportType_VersionStructure
     private BigDecimal formDragCoefficient;
     private BigDecimal rollResistanceCoefficient;
     private BigDecimal maximumEngineEffectKW;
+    @Enumerated(EnumType.STRING)
     private HybridCategoryEnumeration hybridCategory;
 
     @Transient

--- a/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/mapstruct/DataManagedObjectStructureMapper.java
+++ b/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/mapstruct/DataManagedObjectStructureMapper.java
@@ -138,9 +138,17 @@ public interface DataManagedObjectStructureMapper {
             @MappingTarget DataManagedObjectStructure netexEntity,
             @Context MappingContext context
     ) {
-        netexEntity.setKeyList(context.getKeyListStructureMapper().mapToNetex(sobekEntity.getKeyValues(), context));
-        if (netexEntity.getKeyList() == null) {
-            netexEntity.withKeyList(new KeyListStructure());
+        var keyList = context.getKeyListStructureMapper().mapToNetex(sobekEntity.getKeyValues(), context);
+        if (keyList == null) {
+            if (netexEntity.getKeyList() == null) {
+                netexEntity.withKeyList(new KeyListStructure());
+            }
+        } else {
+            if(netexEntity.getKeyList() == null) {
+                netexEntity.withKeyList(keyList);
+            } else {
+                netexEntity.getKeyList().withKeyValue(keyList.getKeyValue());
+            }
         }
 
         sobekEntityGetFunctions.forEach((property, function) ->

--- a/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/mapstruct/DataManagedObjectStructureMapper.java
+++ b/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/mapstruct/DataManagedObjectStructureMapper.java
@@ -217,7 +217,9 @@ public interface DataManagedObjectStructureMapper {
 
         if(!Strings.isNullOrEmpty(keytoAdd) && !Strings.isNullOrEmpty(valueToAdd)) {
             logger.trace("Adding key {} and value {}", keytoAdd, valueToAdd);
-            sobekEntity.getOrCreateValues(keytoAdd).add(valueToAdd);
+            var values = sobekEntity.getOrCreateValues(keytoAdd);
+            values.clear();  // Clear existing values for this key
+            values.add(valueToAdd);  // Add the new value
         }
     }
 

--- a/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/mapstruct/PassengerCapacityMapper.java
+++ b/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/mapstruct/PassengerCapacityMapper.java
@@ -41,26 +41,4 @@ public interface PassengerCapacityMapper {
             @MappingTarget org.rutebanken.sobek.model.vehicle.PassengerCapacity target,
             @Context MappingContext context
     );
-
-    @AfterMapping
-    default void afterMapToSobek(
-            PassengerCapacityStructure source,
-            @MappingTarget org.rutebanken.sobek.model.vehicle.PassengerCapacity target,
-            @Context MappingContext context
-    ) {
-        if (target != null) {
-            context.getDataManagedObjectStructureMapper().afterMappingToSobek(source, target, context);
-        }
-    }
-    @AfterMapping
-    default void afterMapToNetex(
-            org.rutebanken.sobek.model.vehicle.PassengerCapacity source,
-            @MappingTarget PassengerCapacityStructure target,
-            @Context MappingContext context
-    ) {
-        if (target != null) {
-            context.getDataManagedObjectStructureMapper().afterMappingToNetex(source, target, context);
-        }
-    }
-
 }

--- a/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/mapstruct/VehicleMapper.java
+++ b/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/mapstruct/VehicleMapper.java
@@ -93,9 +93,6 @@ public interface VehicleMapper {
             @MappingTarget org.rutebanken.sobek.model.vehicle.Vehicle target,
             @Context MappingContext context
     ) {
-        if (target != null) {
-            context.getDataManagedObjectStructureMapper().afterMappingToSobek(source, target, context);
-        }
         // Extract and resolve TransportTypeRef if present
         if (source.getTransportTypeRef() != null && source.getTransportTypeRef().getValue() != null) {
             TransportTypeRefStructure transportTypeRefStructure = source.getTransportTypeRef().getValue();
@@ -138,10 +135,6 @@ public interface VehicleMapper {
             @MappingTarget Vehicle target,
             @Context MappingContext context
     ) {
-        if (target != null) {
-            context.getDataManagedObjectStructureMapper().afterMappingToNetex(source, target, context);
-        }
-
         // Handle TransportType -> TransportTypeRef wrapping
         if (source.getTransportType() != null && source.getTransportType().getNetexId() != null) {
             // Create reference from actual entity

--- a/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/mapstruct/VehicleModelMapper.java
+++ b/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/mapstruct/VehicleModelMapper.java
@@ -71,10 +71,6 @@ public interface VehicleModelMapper {
             @MappingTarget org.rutebanken.sobek.model.vehicle.VehicleModel target,
             @Context MappingContext context
     ) {
-        if (target != null) {
-            context.getDataManagedObjectStructureMapper().afterMappingToSobek(source, target, context);
-        }
-
         // Extract and resolve TransportTypeRef if present
         if (source.getTransportTypeRef() != null && source.getTransportTypeRef().getValue() != null) {
             TransportTypeRefStructure transportTypeRefStructure = source.getTransportTypeRef().getValue();
@@ -101,10 +97,6 @@ public interface VehicleModelMapper {
             @MappingTarget VehicleModel target,
             @Context MappingContext context
     ) {
-        if (target != null) {
-            context.getDataManagedObjectStructureMapper().afterMappingToNetex(source, target, context);
-        }
-
         // Handle TransportType -> TransportTypeRef wrapping
         if (source.getTransportType() != null && source.getTransportType().getNetexId() != null) {
             // Create reference from actual entity

--- a/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/mapstruct/VehicleTypeMapper.java
+++ b/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/mapstruct/VehicleTypeMapper.java
@@ -5,8 +5,12 @@ import org.rutebanken.netex.model.DeckPlanRefStructure;
 import org.rutebanken.netex.model.ObjectFactory;
 import org.rutebanken.netex.model.VehicleType;
 import org.rutebanken.sobek.model.vehicle.DeckPlan;
+import org.rutebanken.sobek.model.vehicle.HybridCategoryEnumeration;
 import org.rutebanken.sobek.netex.mapping.config.SobekMapperConfig;
 import org.rutebanken.sobek.netex.mapping.context.MappingContext;
+import org.rutebanken.sobek.netex.util.KeyValuesHelper;
+
+import java.math.BigDecimal;
 
 
 /**
@@ -86,6 +90,10 @@ public interface VehicleTypeMapper {
     ) {
         if (target != null) {
             context.getDataManagedObjectStructureMapper().afterMappingToSobek(source, target, context);
+            KeyValuesHelper.SetFromKeyValues("FormDragCoefficient", source.getKeyList(), BigDecimal::new, target::setFormDragCoefficient);
+            KeyValuesHelper.SetFromKeyValues("RollResistanceCoefficient", source.getKeyList(), BigDecimal::new, target::setRollResistanceCoefficient);
+            KeyValuesHelper.SetFromKeyValues("MaximumEngineEffectKW", source.getKeyList(), BigDecimal::new, target::setMaximumEngineEffectKW);
+            KeyValuesHelper.SetFromKeyValues("HybridCategory", source.getKeyList(), HybridCategoryEnumeration::fromValue, target::setHybridCategory);
         }
 
         // Extract and resolve DeckPlanRef if present
@@ -116,6 +124,13 @@ public interface VehicleTypeMapper {
     ) {
         if (target != null) {
             context.getDataManagedObjectStructureMapper().afterMappingToNetex(source, target, context);
+        }
+
+        if(target != null) {
+            KeyValuesHelper.AddToKeyValues(target, "FormDragCoefficient", source.getFormDragCoefficient() == null ? null : String.valueOf(source.getFormDragCoefficient()));
+            KeyValuesHelper.AddToKeyValues(target, "RollResistanceCoefficient", source.getRollResistanceCoefficient() == null ? null : String.valueOf(source.getRollResistanceCoefficient()));
+            KeyValuesHelper.AddToKeyValues(target, "MaximumEngineEffectKW", source.getMaximumEngineEffectKW() == null ? null : String.valueOf(source.getMaximumEngineEffectKW()));
+            KeyValuesHelper.AddToKeyValues(target, "HybridCategory", source.getHybridCategory() == null ? null : String.valueOf(source.getHybridCategory()));
         }
 
         // Handle DeckPlanRef creation from entity or transient reference

--- a/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/mapstruct/VehicleTypeMapper.java
+++ b/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/mapstruct/VehicleTypeMapper.java
@@ -126,7 +126,7 @@ public interface VehicleTypeMapper {
             KeyValuesHelper.SetToKeyValues(target, "FormDragCoefficient", source.getFormDragCoefficient() == null ? null : String.valueOf(source.getFormDragCoefficient()));
             KeyValuesHelper.SetToKeyValues(target, "RollResistanceCoefficient", source.getRollResistanceCoefficient() == null ? null : String.valueOf(source.getRollResistanceCoefficient()));
             KeyValuesHelper.SetToKeyValues(target, "MaximumEngineEffectKW", source.getMaximumEngineEffectKW() == null ? null : String.valueOf(source.getMaximumEngineEffectKW()));
-            KeyValuesHelper.SetToKeyValues(target, "HybridCategory", source.getHybridCategory() == null ? null : String.valueOf(source.getHybridCategory()));
+            KeyValuesHelper.SetToKeyValues(target, "HybridCategory", source.getHybridCategory() == null ? null : source.getHybridCategory().value());
         }
 
         // Handle DeckPlanRef creation from entity or transient reference

--- a/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/mapstruct/VehicleTypeMapper.java
+++ b/sobek-service/src/main/java/org/rutebanken/sobek/netex/mapping/mapstruct/VehicleTypeMapper.java
@@ -122,15 +122,11 @@ public interface VehicleTypeMapper {
             @MappingTarget VehicleType target,
             @Context MappingContext context
     ) {
-        if (target != null) {
-            context.getDataManagedObjectStructureMapper().afterMappingToNetex(source, target, context);
-        }
-
         if(target != null) {
-            KeyValuesHelper.AddToKeyValues(target, "FormDragCoefficient", source.getFormDragCoefficient() == null ? null : String.valueOf(source.getFormDragCoefficient()));
-            KeyValuesHelper.AddToKeyValues(target, "RollResistanceCoefficient", source.getRollResistanceCoefficient() == null ? null : String.valueOf(source.getRollResistanceCoefficient()));
-            KeyValuesHelper.AddToKeyValues(target, "MaximumEngineEffectKW", source.getMaximumEngineEffectKW() == null ? null : String.valueOf(source.getMaximumEngineEffectKW()));
-            KeyValuesHelper.AddToKeyValues(target, "HybridCategory", source.getHybridCategory() == null ? null : String.valueOf(source.getHybridCategory()));
+            KeyValuesHelper.SetToKeyValues(target, "FormDragCoefficient", source.getFormDragCoefficient() == null ? null : String.valueOf(source.getFormDragCoefficient()));
+            KeyValuesHelper.SetToKeyValues(target, "RollResistanceCoefficient", source.getRollResistanceCoefficient() == null ? null : String.valueOf(source.getRollResistanceCoefficient()));
+            KeyValuesHelper.SetToKeyValues(target, "MaximumEngineEffectKW", source.getMaximumEngineEffectKW() == null ? null : String.valueOf(source.getMaximumEngineEffectKW()));
+            KeyValuesHelper.SetToKeyValues(target, "HybridCategory", source.getHybridCategory() == null ? null : String.valueOf(source.getHybridCategory()));
         }
 
         // Handle DeckPlanRef creation from entity or transient reference

--- a/sobek-service/src/test/java/org/rutebanken/sobek/netex/mapping/mapstruct/VehicleTypeMapperTest.java
+++ b/sobek-service/src/test/java/org/rutebanken/sobek/netex/mapping/mapstruct/VehicleTypeMapperTest.java
@@ -1,12 +1,8 @@
 package org.rutebanken.sobek.netex.mapping.mapstruct;
 
 import org.junit.jupiter.api.Test;
-import org.rutebanken.netex.model.AllPublicTransportModesEnumeration;
-import org.rutebanken.netex.model.DeckPlanRefStructure;
-import org.rutebanken.netex.model.FuelTypeEnumeration;
-import org.rutebanken.netex.model.PassengerCapacityStructure;
-import org.rutebanken.netex.model.PropulsionTypeEnumeration;
-import org.rutebanken.netex.model.VehicleType;
+import org.rutebanken.netex.model.*;
+import org.rutebanken.sobek.model.vehicle.HybridCategoryEnumeration;
 import org.rutebanken.sobek.netex.mapping.context.MappingContext;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -45,6 +41,11 @@ class VehicleTypeMapperTest {
         netexVehicleType.setMaximumVelocity(new BigDecimal("100"));
         netexVehicleType.setEuroClass("Euro6");
         netexVehicleType.setTransportMode(AllPublicTransportModesEnumeration.BUS);
+        netexVehicleType.withKeyList(new KeyListStructure().withKeyValue(
+                new KeyValueStructure().withKey("FormDragCoefficient").withValue("0.4"),
+                new KeyValueStructure().withKey("MaximumEngineEffectKW").withValue("500"),
+                new KeyValueStructure().withKey("HybridCategory").withValue("chargeable")
+        ));
 
         // Passenger capacity
         PassengerCapacityStructure capacity = new PassengerCapacityStructure();
@@ -101,6 +102,11 @@ class VehicleTypeMapperTest {
         assertNotNull(sobekVehicleType.getPropulsionTypes());
         assertEquals(2, sobekVehicleType.getPropulsionTypes().size());
 
+        assertEquals(BigDecimal.valueOf(0.4), sobekVehicleType.getFormDragCoefficient());
+        assertNull(sobekVehicleType.getRollResistanceCoefficient());
+        assertEquals(BigDecimal.valueOf(500), sobekVehicleType.getMaximumEngineEffectKW());
+        assertEquals(HybridCategoryEnumeration.CHARGEABLE, sobekVehicleType.getHybridCategory());
+
         // Check deck plan ref is stored
         //assertNotNull(sobekVehicleType.getDeckPlanRef());
         //assertEquals("DP:1", sobekVehicleType.getDeckPlanRef().getRef());
@@ -118,6 +124,7 @@ class VehicleTypeMapperTest {
         sobekVehicleType.setWeight(new BigDecimal("12000"));
         sobekVehicleType.setMaximumVelocity(new BigDecimal("100"));
         sobekVehicleType.setEuroClass("Euro6");
+        sobekVehicleType.setFormDragCoefficient(BigDecimal.valueOf(0.4));
 
         // Set deck plan ref in transient field
         DeckPlanRefStructure deckPlanRef = new DeckPlanRefStructure();
@@ -136,6 +143,10 @@ class VehicleTypeMapperTest {
         assertEquals(new BigDecimal("12000"), netexVehicleType.getWeight());
         assertEquals(new BigDecimal("100"), netexVehicleType.getMaximumVelocity());
         assertEquals("Euro6", netexVehicleType.getEuroClass());
+
+        var keyList = netexVehicleType.getKeyList();
+        keyList.getKeyValue().stream().filter(kv -> kv.getKey().equals("FormDragCoefficient")).findFirst().ifPresent(kv -> assertEquals("0.4", kv.getValue()));
+        keyList.getKeyValue().stream().filter(kv -> kv.getKey().equals("RollResitanceCoefficient")).findFirst().ifPresent(kv -> assertNull(kv.getValue()));
 
         // Check deck plan ref
         //assertNotNull(netexVehicleType.getDeckPlanRef());

--- a/sobek-service/src/test/java/org/rutebanken/sobek/netex/mapping/mapstruct/VehicleTypeMapperTest.java
+++ b/sobek-service/src/test/java/org/rutebanken/sobek/netex/mapping/mapstruct/VehicleTypeMapperTest.java
@@ -125,6 +125,7 @@ class VehicleTypeMapperTest {
         sobekVehicleType.setMaximumVelocity(new BigDecimal("100"));
         sobekVehicleType.setEuroClass("Euro6");
         sobekVehicleType.setFormDragCoefficient(BigDecimal.valueOf(0.4));
+        sobekVehicleType.setHybridCategory(HybridCategoryEnumeration.CHARGEABLE);
 
         // Set deck plan ref in transient field
         DeckPlanRefStructure deckPlanRef = new DeckPlanRefStructure();
@@ -147,6 +148,7 @@ class VehicleTypeMapperTest {
         var keyList = netexVehicleType.getKeyList();
         keyList.getKeyValue().stream().filter(kv -> kv.getKey().equals("FormDragCoefficient")).findFirst().ifPresent(kv -> assertEquals("0.4", kv.getValue()));
         keyList.getKeyValue().stream().filter(kv -> kv.getKey().equals("RollResitanceCoefficient")).findFirst().ifPresent(kv -> assertNull(kv.getValue()));
+        keyList.getKeyValue().stream().filter(kv -> kv.getKey().equals("HybridCategory")).findFirst().ifPresent(kv -> assertEquals("chargeable", kv.getValue()));
 
         // Check deck plan ref
         //assertNotNull(netexVehicleType.getDeckPlanRef());

--- a/sobek-service/src/test/java/org/rutebanken/sobek/netex/mapping/mapstruct/VehicleTypeMapperTest.java
+++ b/sobek-service/src/test/java/org/rutebanken/sobek/netex/mapping/mapstruct/VehicleTypeMapperTest.java
@@ -146,9 +146,16 @@ class VehicleTypeMapperTest {
         assertEquals("Euro6", netexVehicleType.getEuroClass());
 
         var keyList = netexVehicleType.getKeyList();
-        keyList.getKeyValue().stream().filter(kv -> kv.getKey().equals("FormDragCoefficient")).findFirst().ifPresent(kv -> assertEquals("0.4", kv.getValue()));
-        keyList.getKeyValue().stream().filter(kv -> kv.getKey().equals("RollResitanceCoefficient")).findFirst().ifPresent(kv -> assertNull(kv.getValue()));
-        keyList.getKeyValue().stream().filter(kv -> kv.getKey().equals("HybridCategory")).findFirst().ifPresent(kv -> assertEquals("chargeable", kv.getValue()));
+        var formDragCoefficient = keyList.getKeyValue().stream().filter(kv -> kv.getKey().equals("FormDragCoefficient")).findFirst();
+        assertTrue(formDragCoefficient.isPresent(), "FormDragCoefficient key should be present");
+        assertEquals("0.4", formDragCoefficient.get().getValue());
+
+        var rollResistanceCoefficient = keyList.getKeyValue().stream().filter(kv -> kv.getKey().equals("RollResistanceCoefficient")).findFirst();
+        assertFalse(rollResistanceCoefficient.isPresent(), "RollResistanceCoefficient key should not be present");
+
+        var hybridCategory = keyList.getKeyValue().stream().filter(kv -> kv.getKey().equals("HybridCategory")).findFirst();
+        assertTrue(hybridCategory.isPresent(), "HybridCategory key should be present");
+        assertEquals("chargeable", hybridCategory.get().getValue());
 
         // Check deck plan ref
         //assertNotNull(netexVehicleType.getDeckPlanRef());


### PR DESCRIPTION
### Summary

Add the environmental properties of vehicle type to the model, as native properties in the Sobek model. They are then mapped to/from keyvalues in the NeTEx model

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to documentation only)
- [ ] Other (please describe)